### PR TITLE
docs: clean up CONTRIBUTING template text and link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,3 @@
-> **Customize this file**: Tailor this template to your project by noting specific contribution types you're looking for, adding a Code of Conduct, or adjusting the writing guidelines to match your style.
-
 # Contribute to the documentation
 
 Thank you for your interest in contributing to our documentation! This guide will help you get started.
@@ -22,7 +20,7 @@ Thank you for your interest in contributing to our documentation! This guide wil
 6. Preview your changes at `http://localhost:3000`
 7. Commit your changes and submit a pull request
 
-For more details on local development, see our [development guide](development.mdx).
+For contribution scope and review expectations, see the [contribution model](reference/contribution-model.mdx).
 
 ## Writing guidelines
 


### PR DESCRIPTION
## Summary
- remove leftover template instruction text from `CONTRIBUTING.md`
- replace broken `development.mdx` link with `reference/contribution-model.mdx`

## Why
- keeps contributor guidance repo-specific and avoids a dead link

Related Paperclip issue: [GRO-6](/GRO/issues/GRO-6)