### PR TITLE
feat(site): refactor landing page entry flow

### DIFF
--- a/cases/index.mdx
+++ b/cases/index.mdx
@@ -1,33 +1,40 @@
 ---
-title: Introduction
-description: Examples that show how Grounded Systems behaves in real situations.
+title: Cases
+description: Practical examples that show where friction lives and how a grounded response begins.
 ---
 
 Cases make the model concrete.
 
-They are not polished victory stories. They are examples of where the real constraint often lives, what the wrong move looks like, and how a more grounded response begins.
+They show how Grounded Systems behaves when real systems, real constraints, and real organizational seams are involved. These are not polished success stories. They are working examples of where friction tends to hide, what the wrong move often looks like, and how a more grounded response can begin.
 
-## What these cases are for
+## What the cases help you see
 
 Use them to understand:
 
-- how the model behaves under real pressure
-- where friction usually hides
-- what kind of first moves are useful
-- how anti-patterns show up in practice
+- where the real constraint often lives
+- what kind of first move lowers risk and increases clarity
+- which forms of drift or dependency need to be avoided
+- what capability should remain after the intervention
 
 ## Current cases
 
-- [Legacy modernization](/cases/legacy-modernization)
-- [Vendor friction](/cases/vendor-friction)
-- [Platform seams](/cases/platform-seams)
+<CardGroup cols={3}>
+  <Card title="Legacy modernization" href="/cases/legacy-modernization">
+    Follow the shape of grounded change inside a system that already carries business value.
+  </Card>
+  <Card title="Vendor friction" href="/cases/vendor-friction">
+    See what happens when ownership gets obscured by external delivery and contract boundaries.
+  </Card>
+  <Card title="Platform seams" href="/cases/platform-seams">
+    Study the organizational and technical seams where platform choices often create new drag.
+  </Card>
+</CardGroup>
 
 ## How to read them
 
-Each case should help answer:
+A useful case should help answer four questions:
 
 - what was actually hard
 - where ownership lived
-- what kind of move reduced friction
-- what dependency or drift had to be avoided
-- what capability remained after the intervention
+- what move reduced friction
+- what the team could carry forward afterward

--- a/config/navigation.json
+++ b/config/navigation.json
@@ -1,25 +1,35 @@
 {
   "tabs": [
     {
-      "tab": "Introduction",
+      "tab": "Grounded Systems",
       "groups": [
         {
           "group": "Grounded Systems",
           "pages": [
             "index"
           ]
-        },
+        }
+      ]
+    },
+    {
+      "tab": "Customers",
+      "groups": [
         {
-          "group": "For customers",
+          "group": "For Customers",
           "pages": [
             "customers/index",
             "customers/what-we-help-with",
             "customers/how-we-work",
             "customers/when-we-are-a-fit"
           ]
-        },
+        }
+      ]
+    },
+    {
+      "tab": "Practitioners",
+      "groups": [
         {
-          "group": "For practitioners",
+          "group": "For Practitioners",
           "pages": [
             "practitioners/index",
             "practitioners/who-thrives-here",

--- a/config/navigation.json
+++ b/config/navigation.json
@@ -83,6 +83,7 @@
         {
           "group": "Reference",
           "pages": [
+            "reference/index",
             "reference/glossary",
             "reference/faq",
             "reference/contribution-model"

--- a/customers/index.mdx
+++ b/customers/index.mdx
@@ -1,43 +1,54 @@
 ---
-title: Overview
-description: What Grounded Systems helps with, and where this model fits.
+title: For Customers
+description: What Grounded Systems helps with, how the model works, and when it is a good fit.
 ---
 
-**Grounded Systems** is for organizations that need meaningful progress, but cannot afford change that only looks good on paper.
+Grounded Systems is for organizations that need progress in systems they already rely on.
 
-## What we help with
+This work fits best when modernization matters, but replacing everything, outsourcing the hard parts, or running a big parallel program would add more risk than clarity.
 
-We work best in environments where:
+## Where we help most
 
-- delivery is slow or fragile
-- ownership is unclear
-- systems are hard to change safely
-- teams depend too much on external delivery
-- modernization is needed, but big-bang change is unrealistic
+We are most useful when teams are dealing with problems like these:
 
-## How we work
+- delivery is slower or more fragile than it should be
+- the system is hard to change safely
+- ownership is split across teams or hidden behind process
+- important decisions keep getting pushed outward instead of made close to the work
+- modernization is necessary, but a clean restart is unrealistic
 
-We do not modernize around the client.
+## How the work works
 
-We work with client teams, inside their current systems, using real constraints as the starting point. The goal is not to create dependency. The goal is to help the team become more capable, more confident, and more able to carry change themselves.
+We embed as a small senior unit inside the real environment.
 
-## What you should expect
+That means we work with the team that owns the system, use the current tools and constraints as the starting point, and help create small but meaningful improvements that the team can keep carrying after we leave.
 
-- practical improvements inside the current system
-- clear trade-offs and visible reasoning
-- focus on ownership, not theater
-- gradual reduction of outside dependence
-- a model that treats client capability as the main product
+The goal is not to become your delivery engine. The goal is to help your own teams become more capable, more confident, and more able to move without outside dependence.
 
-## What this is not
+## What good clients should expect
 
-- not staff augmentation
-- not a framework rollout
-- not a sidecar platform strategy
-- not delivery substitution dressed up as transformation
+- practical movement inside the current system
+- clear reasoning and visible trade-offs
+- shared work rather than outside substitution
+- growing confidence and judgment in the host team
+- an exit path designed into the engagement
 
-## Good fit
+## Start with the right path
 
-This model fits when leadership wants capability, not just throughput, and when the host team can own backlog, decisions, and operations.
+<CardGroup cols={2}>
+  <Card title="What we help with" href="/customers/what-we-help-with">
+    See the kinds of delivery, ownership, and modernization problems this model is built to address.
+  </Card>
+  <Card title="How we work" href="/customers/how-we-work">
+    Go deeper on the operating model and how embedded enablement differs from outside substitution.
+  </Card>
+  <Card title="When we are a fit" href="/customers/when-we-are-a-fit">
+    Use the fit guidance to assess readiness, boundaries, and whether the conditions are right.
+  </Card>
+</CardGroup>
 
-If those conditions are absent, the work should not begin.
+## When this is a strong fit
+
+This model works best when leadership wants stronger internal capability, not just more external throughput.
+
+It also works best when the host team can own backlog, decisions, delivery, and operations while we are present. If those conditions are not there yet, the first step is usually to create them.

--- a/docs.json
+++ b/docs.json
@@ -2,12 +2,12 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "luma",
   "name": "Grounded Systems",
-  "description": "Practical modernization from inside the real system.",
+  "description": "Modernize from within, with a small senior team that helps yours make real progress without giving up ownership.",
   "colors": {
     "primary": "#111111"
   },
   "logo": "/images/og-image.png",
-  "favicon": "/images/og-image.png",
+  "favicon": "/images/favicon.ico",
   "appearance": {
     "default": "light",
     "strict": true

--- a/index.mdx
+++ b/index.mdx
@@ -1,43 +1,59 @@
 ---
-title: Introduction
-description: Practical modernization from inside the real system.
+title: Grounded Systems
+description: Modernize from within, with a small senior team that helps yours make real progress without giving up ownership.
 ---
 
-Grounded Systems is a consulting capability for organizations that need real progress inside real constraints.
+Grounded Systems helps organizations modernize from within.
 
-We work where systems, teams, and decisions meet. We help clients modernize from within, strengthen ownership, reduce dependency, and make change easier to carry over time.
+We work inside the real system, with the people who already own it, so change becomes safer, clearer, and easier to carry forward.
+
+## What this looks like
+
+Modernization usually stalls for a reason. The system is active, the constraints are real, and the team still has to run the business while change is happening.
+
+Grounded Systems is a small senior consulting capability that embeds where work is stuck and helps teams make practical progress in place. We do not build a separate track of change around the customer. We work with the existing team, inside the existing environment, and design the work so outside presence tapers over time.
+
+## Start where you fit
+
+<CardGroup cols={2}>
+  <Card title="For customers" href="/customers/index">
+    Understand where this model fits, how the work behaves, and what good clients should expect.
+  </Card>
+  <Card title="For practitioners" href="/practitioners/index">
+    See what this work asks of the people doing it and who tends to thrive in it.
+  </Card>
+  <Card title="Principles" href="/principles/index">
+    Read the decision principles that protect customer ownership and keep the work from drifting.
+  </Card>
+  <Card title="Playbook" href="/playbook/index">
+    Move from stance to practice with guidance for entering, navigating, and exiting real work.
+  </Card>
+  <Card title="Cases" href="/cases/index">
+    Study practical examples that show where friction lives and how a grounded response begins.
+  </Card>
+  <Card title="Reference" href="/reference/index">
+    Use the glossary, FAQ, and contribution guidance when you need stable definitions and direct answers.
+  </Card>
+</CardGroup>
+
+## What we help make possible
+
+- safer progress in systems that are already carrying real value
+- clearer ownership across teams, platforms, and decision paths
+- better technical and organizational judgment close to the work
+- less dependence on outside delivery over time
+- modernization that still holds after we leave
+
+## Why this model matters
+
+Many modernization efforts create movement without capability. A new platform appears. A parallel system gets built. An outside team ships improvements. The customer is still left depending on someone else to keep things moving.
+
+Grounded Systems takes a different approach. We help teams learn while shipping, make visible trade-offs, and strengthen the habits that let them continue on their own.
 
 ## What makes this different
 
-Most consulting models optimize for output, tool adoption, or external delivery.
-
-Grounded Systems is built around a different result:
-
-- stronger client capability
-- clearer ownership
-- practical modernization in place
-- less dependence on outside help
-- progress that still holds after we leave
-
-## Who this is for
-
-- organizations trying to modernize active systems
-- teams slowed by structural friction
-- leaders who want stronger internal capability, not just external speed
-- practitioners who care about judgment, clarity, and real ownership
-
-## What this site is
-
-This site does two jobs:
-
-- it acts as a public entrypoint for potential customers and future team members
-- it acts as a durable knowledge base for the team itself
-
-## Start here
-
-- [For customers](/customers/index)
-- [For practitioners](/practitioners/index)
-- [Principles](/principles/index)
-- [Playbook](/playbook/index)
-- [Cases](/cases/index)
-- [Reference](/reference/index)
+- work happens inside the system that already carries value
+- customer ownership stays close to the real decisions
+- trade-offs stay visible instead of hiding behind process
+- outside help tapers instead of becoming permanent
+- progress is measured by retained capability, not activity volume

--- a/index.mdx
+++ b/index.mdx
@@ -40,3 +40,4 @@ This site does two jobs:
 - [Principles](/principles/index)
 - [Playbook](/playbook/index)
 - [Cases](/cases/index)
+- [Reference](/reference/index)

--- a/playbook/index.mdx
+++ b/playbook/index.mdx
@@ -1,33 +1,56 @@
 ---
-title: Introduction
-description: Actionable guidance for using the model in the wild.
+title: Playbook
+description: Practical guidance for entering, navigating, and exiting real modernization work without losing the plot.
 ---
 
-This section turns the stance into moves.
+The playbook turns the stance into practical moves.
 
-It is not a bag of rituals. It is a working guide for entering, navigating, and leaving real client environments without drifting into theater.
+It is not a fixed method and it is not a bag of rituals. It is a working guide for entering real environments, reading what is happening, and making decisions that help the customer move without creating new dependency.
 
-## What belongs here
+## What you will find here
 
 - entry gate checks
-- discovery prompts
-- decision patterns
-- field signals
+- discovery guidance for reading the real system
+- decision patterns for choosing safe, useful moves
+- field signals that show where friction and drift are hiding
 - sponsor behavior
-- working in the open
+- ways of working in the open
 - taper and exit
-- practical checklists
+- lightweight checklists to support judgment
 
 ## How to use it
 
-Use this section to support judgment in context.
+Use this section to support decisions in context.
 
-The goal is not to copy visible practices. The goal is to make better calls inside real conditions.
+The goal is not to copy visible practices from page to page. The goal is to make better calls inside the real system, with the real team, under real constraints.
+
+## Start with the right move
+
+<CardGroup cols={2}>
+  <Card title="Entry gate" href="/playbook/entry-gate">
+    Use the entry checks to decide whether the work should begin at all.
+  </Card>
+  <Card title="Discovery" href="/playbook/discovery">
+    Read the system, its seams, and its friction before prescribing solutions.
+  </Card>
+  <Card title="Decision patterns" href="/playbook/decision-patterns">
+    Choose moves that are safer, clearer, and easier for the customer to own.
+  </Card>
+  <Card title="Field signals" href="/playbook/field-signals">
+    Notice the patterns that suggest drift, dependency, or hidden constraints.
+  </Card>
+  <Card title="Sponsor behavior" href="/playbook/sponsor-behavior">
+    Understand the leadership behaviors that make this work easier or impossible.
+  </Card>
+  <Card title="Taper and exit" href="/playbook/taper-and-exit">
+    Keep the engagement moving toward lower dependence instead of permanent presence.
+  </Card>
+</CardGroup>
 
 ## The anchor question
 
 When in doubt, ask:
 
-**Will this lower the client’s cost of change after we leave?**
+**Will this leave the customer more able to continue after we leave?**
 
 If the answer is no, the move is probably wrong, premature, or too heavy.

--- a/practitioners/index.mdx
+++ b/practitioners/index.mdx
@@ -1,41 +1,43 @@
 ---
-title: Overview
-description: What kind of people fit this work, and what it demands.
+title: For Practitioners
+description: What this work asks of the people doing it, and who tends to thrive in it.
 ---
 
-This work is not built for people who need a fixed script.
+This work is for practitioners who can enter a real environment, understand what is actually happening, and help a team move without taking over.
 
-It is built for people who can enter complex environments, read what is actually happening, and help others move without taking over.
+It suits people who care about systems, judgment, and the quiet work of making others more capable.
 
-## The kind of person who fits here
+## The kind of practitioner who tends to fit
 
-Useful practitioners tend to be:
+People who thrive here are usually:
 
-- calm under ambiguity
+- calm in messy environments
 - curious before certain
-- practical rather than decorative
+- practical in both language and action
 - able to teach while doing
-- comfortable challenging assumptions
-- able to work across technical and organizational seams
+- comfortable working across technical and organizational seams
+- willing to challenge assumptions without making themselves the center of gravity
 
-## What this work demands
+## What the work asks of you
 
-This work requires more than technical strength.
+This is not just technical execution.
 
-It demands judgment, timing, restraint, and the ability to help teams become stronger without making yourself the center of gravity.
+It asks for timing, restraint, pattern recognition, and the ability to help teams grow stronger while still making real progress. You have to read the system in front of you, notice where friction actually lives, and choose moves the customer can own at 02:00, not just in a presentation.
 
-## What does not fit
+## Explore the practitioner path
 
-This is a poor fit for people who:
-
-- hide behind process
-- rush to tools before understanding context
-- equate delivery speed with value
-- optimize for being the smartest person in the room
-- need control in order to operate
+<CardGroup cols={2}>
+  <Card title="Who thrives here" href="/practitioners/who-thrives-here">
+    Get more specific about the traits and operating habits that make this work sustainable.
+  </Card>
+  <Card title="How we think" href="/practitioners/how-we-think">
+    See the decision style and working posture expected from Grounded Systems practitioners.
+  </Card>
+  <Card title="What this work demands" href="/practitioners/what-this-work-demands">
+    Read the practical bar for judgment, restraint, and delivery integrity in the field.
+  </Card>
+</CardGroup>
 
 ## Why this matters
 
-The team is not meant to become another generic consulting unit.
-
-It is meant to build something differentiated, grounded in strong technical leadership, direct communication, low politics, and delivery integrity.
+Grounded Systems is meant to be a small senior capability with a clear identity. That only works if the people doing the work value clarity, ownership, low politics, and delivery integrity more than status or control.

--- a/principles/index.mdx
+++ b/principles/index.mdx
@@ -1,33 +1,41 @@
 ---
-title: Introduction
-description: The core stance behind Grounded Systems.
+title: Principles
+description: The principles that shape how Grounded Systems makes decisions and avoids drift.
 ---
 
-Grounded Systems starts from a simple position: ***Real modernization must happen where the value already lives.***
+These principles exist to keep the work clear when pressure rises.
 
-## Core stance
+They are not slogans. They are practical constraints that protect customer ownership, keep modernization grounded in the real system, and reduce the chance that good intent turns into dependency.
 
-We believe that:
+## The principles
 
-- legacy systems are value carriers, not waste
-- modernization must start inside the existing system
-- tools are context-sensitive decisions, not transformation levers
-- customer ownership matters more than external output
-- progress must lower the future cost of change
+- **Customer ownership comes first.** Client teams own backlog, decisions, delivery, and operations from day one.
+- **Modernize in place.** Start where the value already lives instead of defaulting to parallel replacement.
+- **Capability matters more than output volume.** Progress only counts if the customer becomes more able to continue without us.
+- **Tools follow context.** Tooling choices should lower friction and be clearly owned, not act as transformation theater.
+- **Simplicity and reversibility first.** Prefer moves that are easier to explain, easier to operate, and cheaper to undo.
+- **Work in the open.** Keep reasoning, trade-offs, and ownership visible near the work.
+- **Design exit into the model.** If success depends on permanent outside presence, the engagement has drifted.
 
-## Operating principles
+## Explore the principle set
 
-- customer ownership always
-- advisory and enabling, not managerial
-- simplicity and reversibility first
-- work in the open
-- introduce only what the client can own
-- design exit into the model from the beginning
+<CardGroup cols={2}>
+  <Card title="Core principles" href="/principles/core-principles">
+    Read the full stance in a tighter summary of what Grounded Systems protects and why.
+  </Card>
+  <Card title="Anti-patterns" href="/principles/anti-patterns">
+    Study the failure modes that create motion without capability or ownership.
+  </Card>
+  <Card title="Engagement model" href="/principles/engagement-model">
+    See how these principles shape the way work is structured in practice.
+  </Card>
+  <Card title="Grounded practitioners" href="/principles/grounded-practitioners">
+    Connect the principles to the expectations placed on the people doing the work.
+  </Card>
+</CardGroup>
 
-## Why these principles exist
+## Why these principles matter
 
-Many modernization efforts fail because they create movement without capability.
+A lot of modernization effort fails for the same reason: it creates visible movement without leaving behind judgment, confidence, or durable ownership.
 
-They generate output, but leave the client just as dependent as before.
-
-Grounded Systems treats independence, confidence, and durable ownership as the real success signals.
+These principles exist to prevent that failure mode.

--- a/reference/index.mdx
+++ b/reference/index.mdx
@@ -1,0 +1,20 @@
+---
+title: Introduction
+description: Shared definitions, common questions, and guidance for growing the site.
+---
+
+This section holds the stable reference material for Grounded Systems.
+
+Use it when you need quick definitions, direct answers, or guidance on how the documentation should evolve without losing its shape.
+
+## What belongs here
+
+- glossary terms that keep the language precise
+- common questions with direct answers
+- contribution guidance for keeping the site coherent over time
+
+## Start here
+
+- [Glossary](/reference/glossary)
+- [FAQ](/reference/faq)
+- [Contribution model](/reference/contribution-model)

--- a/reference/index.mdx
+++ b/reference/index.mdx
@@ -1,20 +1,28 @@
 ---
-title: Introduction
-description: Shared definitions, common questions, and guidance for growing the site.
+title: Reference
+description: Stable definitions, direct answers, and guidance that keeps the site coherent over time.
 ---
 
-This section holds the stable reference material for Grounded Systems.
+The reference section holds the stable material that supports the rest of the site.
 
-Use it when you need quick definitions, direct answers, or guidance on how the documentation should evolve without losing its shape.
+Use it when you need a precise definition, a direct answer, or guidance on how the documentation should evolve without losing its shape.
 
 ## What belongs here
 
-- glossary terms that keep the language precise
-- common questions with direct answers
-- contribution guidance for keeping the site coherent over time
+- glossary terms that keep the language clear and consistent
+- common questions with short, direct answers
+- contribution guidance for growing the site without drifting into noise
 
 ## Start here
 
-- [Glossary](/reference/glossary)
-- [FAQ](/reference/faq)
-- [Contribution model](/reference/contribution-model)
+<CardGroup cols={3}>
+  <Card title="Glossary" href="/reference/glossary">
+    Use the stable definitions that keep the language precise across the site.
+  </Card>
+  <Card title="FAQ" href="/reference/faq">
+    Get direct answers to recurring questions without wading through the broader narrative.
+  </Card>
+  <Card title="Contribution model" href="/reference/contribution-model">
+    Follow the guidance for growing the documentation without losing coherence.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary
- refactor the homepage into a clearer entry flow aligned to the approved UX/content handoffs
- rewrite section landing pages for Customers, Practitioners, Principles, Playbook, Cases, and Reference
- promote Customers and Practitioners to top-level navigation in `docs.json`
- align site metadata and favicon in `docs.json`

## Source Inputs
- UX direction: GRO-14
- Content handoff: GRO-15
- Parent task: GRO-13

## Validation
- Mint preview served successfully using a Node 20 fallback runtime