### PR TITLE
docs(ux): polish navigation and landing page chrome

### DIFF
--- a/cases/index.mdx
+++ b/cases/index.mdx
@@ -19,13 +19,13 @@ Use them to understand:
 ## Current cases
 
 <CardGroup cols={3}>
-  <Card title="Legacy modernization" href="/cases/legacy-modernization">
+  <Card title="Legacy modernization" icon="wrench" href="/cases/legacy-modernization" cta="Read the case" arrow>
     Follow the shape of grounded change inside a system that already carries business value.
   </Card>
-  <Card title="Vendor friction" href="/cases/vendor-friction">
+  <Card title="Vendor friction" icon="hand" href="/cases/vendor-friction" cta="Read the case" arrow>
     See what happens when ownership gets obscured by external delivery and contract boundaries.
   </Card>
-  <Card title="Platform seams" href="/cases/platform-seams">
+  <Card title="Platform seams" icon="split" href="/cases/platform-seams" cta="Read the case" arrow>
     Study the organizational and technical seams where platform choices often create new drag.
   </Card>
 </CardGroup>

--- a/config/navigation.json
+++ b/config/navigation.json
@@ -1,19 +1,14 @@
 {
   "tabs": [
     {
-      "tab": "Grounded Systems",
+      "tab": "Start",
       "groups": [
         {
           "group": "Grounded Systems",
           "pages": [
             "index"
           ]
-        }
-      ]
-    },
-    {
-      "tab": "Customers",
-      "groups": [
+        },
         {
           "group": "For Customers",
           "pages": [
@@ -22,12 +17,7 @@
             "customers/how-we-work",
             "customers/when-we-are-a-fit"
           ]
-        }
-      ]
-    },
-    {
-      "tab": "Practitioners",
-      "groups": [
+        },
         {
           "group": "For Practitioners",
           "pages": [
@@ -40,7 +30,7 @@
       ]
     },
     {
-      "tab": "Principles",
+      "tab": "Method",
       "groups": [
         {
           "group": "Principles",
@@ -51,12 +41,7 @@
             "principles/engagement-model",
             "principles/grounded-practitioners"
           ]
-        }
-      ]
-    },
-    {
-      "tab": "Playbook",
-      "groups": [
+        },
         {
           "group": "Playbook",
           "pages": [

--- a/customers/index.mdx
+++ b/customers/index.mdx
@@ -36,13 +36,13 @@ The goal is not to become your delivery engine. The goal is to help your own tea
 ## Start with the right path
 
 <CardGroup cols={2}>
-  <Card title="What we help with" href="/customers/what-we-help-with">
+  <Card title="What we help with" icon="target" href="/customers/what-we-help-with" cta="See focus areas" arrow>
     See the kinds of delivery, ownership, and modernization problems this model is built to address.
   </Card>
-  <Card title="How we work" href="/customers/how-we-work">
+  <Card title="How we work" icon="handshake" href="/customers/how-we-work" cta="Review the model" arrow>
     Go deeper on the operating model and how embedded enablement differs from outside substitution.
   </Card>
-  <Card title="When we are a fit" href="/customers/when-we-are-a-fit">
+  <Card title="When we are a fit" icon="check-circle-2" href="/customers/when-we-are-a-fit" cta="Run the fit check" arrow>
     Use the fit guidance to assess readiness, boundaries, and whether the conditions are right.
   </Card>
 </CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -12,10 +12,29 @@
     "default": "light",
     "strict": true
   },
+  "fonts": {
+    "heading": {
+      "family": "Fraunces"
+    },
+    "body": {
+      "family": "Source Sans 3"
+    }
+  },
+  "icons": {
+    "library": "lucide"
+  },
+  "styling": {
+    "eyebrows": "breadcrumbs"
+  },
   "navigation": {
     "$ref": "./config/navigation.json"
   },
   "navbar": {
+    "primary": {
+      "type": "button",
+      "label": "Start a Conversation",
+      "href": "https://github.com/lagebj/docs/issues/new"
+    },
     "links": [
       {
         "label": "GitHub",

--- a/index.mdx
+++ b/index.mdx
@@ -16,22 +16,22 @@ Grounded Systems is a small senior consulting capability that embeds where work 
 ## Start where you fit
 
 <CardGroup cols={2}>
-  <Card title="For customers" href="/customers/index">
+  <Card title="For customers" icon="building-2" href="/customers/index" cta="See customer fit" arrow>
     Understand where this model fits, how the work behaves, and what good clients should expect.
   </Card>
-  <Card title="For practitioners" href="/practitioners/index">
+  <Card title="For practitioners" icon="users" href="/practitioners/index" cta="Explore the role" arrow>
     See what this work asks of the people doing it and who tends to thrive in it.
   </Card>
-  <Card title="Principles" href="/principles/index">
+  <Card title="Principles" icon="compass" href="/principles/index" cta="Read the principles" arrow>
     Read the decision principles that protect customer ownership and keep the work from drifting.
   </Card>
-  <Card title="Playbook" href="/playbook/index">
+  <Card title="Playbook" icon="book-open" href="/playbook/index" cta="Use the playbook" arrow>
     Move from stance to practice with guidance for entering, navigating, and exiting real work.
   </Card>
-  <Card title="Cases" href="/cases/index">
+  <Card title="Cases" icon="route" href="/cases/index" cta="Review the cases" arrow>
     Study practical examples that show where friction lives and how a grounded response begins.
   </Card>
-  <Card title="Reference" href="/reference/index">
+  <Card title="Reference" icon="library" href="/reference/index" cta="Open reference" arrow>
     Use the glossary, FAQ, and contribution guidance when you need stable definitions and direct answers.
   </Card>
 </CardGroup>

--- a/playbook/index.mdx
+++ b/playbook/index.mdx
@@ -27,22 +27,22 @@ The goal is not to copy visible practices from page to page. The goal is to make
 ## Start with the right move
 
 <CardGroup cols={2}>
-  <Card title="Entry gate" href="/playbook/entry-gate">
+  <Card title="Entry gate" icon="door-open" href="/playbook/entry-gate" cta="Run entry checks" arrow>
     Use the entry checks to decide whether the work should begin at all.
   </Card>
-  <Card title="Discovery" href="/playbook/discovery">
+  <Card title="Discovery" icon="search" href="/playbook/discovery" cta="Read the system" arrow>
     Read the system, its seams, and its friction before prescribing solutions.
   </Card>
-  <Card title="Decision patterns" href="/playbook/decision-patterns">
+  <Card title="Decision patterns" icon="git-branch" href="/playbook/decision-patterns" cta="Choose safer moves" arrow>
     Choose moves that are safer, clearer, and easier for the customer to own.
   </Card>
-  <Card title="Field signals" href="/playbook/field-signals">
+  <Card title="Field signals" icon="radar" href="/playbook/field-signals" cta="Spot weak signals" arrow>
     Notice the patterns that suggest drift, dependency, or hidden constraints.
   </Card>
-  <Card title="Sponsor behavior" href="/playbook/sponsor-behavior">
+  <Card title="Sponsor behavior" icon="megaphone" href="/playbook/sponsor-behavior" cta="Guide sponsor action" arrow>
     Understand the leadership behaviors that make this work easier or impossible.
   </Card>
-  <Card title="Taper and exit" href="/playbook/taper-and-exit">
+  <Card title="Taper and exit" icon="hourglass" href="/playbook/taper-and-exit" cta="Design the exit" arrow>
     Keep the engagement moving toward lower dependence instead of permanent presence.
   </Card>
 </CardGroup>

--- a/practitioners/index.mdx
+++ b/practitioners/index.mdx
@@ -27,13 +27,13 @@ It asks for timing, restraint, pattern recognition, and the ability to help team
 ## Explore the practitioner path
 
 <CardGroup cols={2}>
-  <Card title="Who thrives here" href="/practitioners/who-thrives-here">
+  <Card title="Who thrives here" icon="user-round-check" href="/practitioners/who-thrives-here" cta="See the profile" arrow>
     Get more specific about the traits and operating habits that make this work sustainable.
   </Card>
-  <Card title="How we think" href="/practitioners/how-we-think">
+  <Card title="How we think" icon="brain-circuit" href="/practitioners/how-we-think" cta="Read the posture" arrow>
     See the decision style and working posture expected from Grounded Systems practitioners.
   </Card>
-  <Card title="What this work demands" href="/practitioners/what-this-work-demands">
+  <Card title="What this work demands" icon="shield-check" href="/practitioners/what-this-work-demands" cta="Understand the bar" arrow>
     Read the practical bar for judgment, restraint, and delivery integrity in the field.
   </Card>
 </CardGroup>

--- a/principles/index.mdx
+++ b/principles/index.mdx
@@ -20,16 +20,16 @@ They are not slogans. They are practical constraints that protect customer owner
 ## Explore the principle set
 
 <CardGroup cols={2}>
-  <Card title="Core principles" href="/principles/core-principles">
+  <Card title="Core principles" icon="badge-check" href="/principles/core-principles" cta="See the full set" arrow>
     Read the full stance in a tighter summary of what Grounded Systems protects and why.
   </Card>
-  <Card title="Anti-patterns" href="/principles/anti-patterns">
+  <Card title="Anti-patterns" icon="triangle-alert" href="/principles/anti-patterns" cta="Review failure modes" arrow>
     Study the failure modes that create motion without capability or ownership.
   </Card>
-  <Card title="Engagement model" href="/principles/engagement-model">
+  <Card title="Engagement model" icon="network" href="/principles/engagement-model" cta="Understand structure" arrow>
     See how these principles shape the way work is structured in practice.
   </Card>
-  <Card title="Grounded practitioners" href="/principles/grounded-practitioners">
+  <Card title="Grounded practitioners" icon="user-cog" href="/principles/grounded-practitioners" cta="Connect to practice" arrow>
     Connect the principles to the expectations placed on the people doing the work.
   </Card>
 </CardGroup>

--- a/reference/index.mdx
+++ b/reference/index.mdx
@@ -16,13 +16,13 @@ Use it when you need a precise definition, a direct answer, or guidance on how t
 ## Start here
 
 <CardGroup cols={3}>
-  <Card title="Glossary" href="/reference/glossary">
+  <Card title="Glossary" icon="book-a" href="/reference/glossary" cta="Open glossary" arrow>
     Use the stable definitions that keep the language precise across the site.
   </Card>
-  <Card title="FAQ" href="/reference/faq">
+  <Card title="FAQ" icon="circle-help" href="/reference/faq" cta="Read FAQs" arrow>
     Get direct answers to recurring questions without wading through the broader narrative.
   </Card>
-  <Card title="Contribution model" href="/reference/contribution-model">
+  <Card title="Contribution model" icon="git-pull-request" href="/reference/contribution-model" cta="See contribution rules" arrow>
     Follow the guidance for growing the documentation without losing coherence.
   </Card>
 </CardGroup>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,52 @@
+:root {
+  --gs-chrome-shadow: 0 10px 28px rgba(17, 17, 17, 0.08);
+  --gs-border-muted: rgba(17, 17, 17, 0.1);
+  --gs-surface-soft: linear-gradient(180deg, rgba(17, 17, 17, 0.03) 0%, rgba(17, 17, 17, 0.01) 100%);
+  --gs-space-vertical: clamp(2.5rem, 2rem + 1vw, 3.5rem);
+}
+
+#navbar {
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--gs-border-muted);
+  box-shadow: 0 6px 24px rgba(17, 17, 17, 0.05);
+}
+
+#navbar .nav-tabs {
+  gap: 0.35rem;
+}
+
+#navbar .nav-tabs a {
+  border-radius: 999px;
+  padding: 0.32rem 0.7rem;
+}
+
+#content-area {
+  padding-top: var(--gs-space-vertical);
+}
+
+.card {
+  border: 1px solid var(--gs-border-muted);
+  border-radius: 14px;
+  background: var(--gs-surface-soft);
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--gs-chrome-shadow);
+  border-color: rgba(17, 17, 17, 0.2);
+}
+
+.card:focus-within {
+  border-color: rgba(17, 17, 17, 0.35);
+  box-shadow: 0 0 0 2px rgba(17, 17, 17, 0.1);
+}
+
+#footer {
+  border-top: 1px solid var(--gs-border-muted);
+}
+
+.toc {
+  border-left: 1px solid var(--gs-border-muted);
+  padding-left: 1rem;
+}


### PR DESCRIPTION
## Summary
- reduce top-level navigation tabs from 7 to 4 while preserving all pages
- add Mintlify UX polish in `docs.json` (fonts, lucide icons, breadcrumb eyebrows, primary navbar CTA)
- add a global `style.css` for restrained navbar/card/footer/toc/content spacing improvements
- refresh section landing pages with card icons, CTA labels, and arrow affordance

## Validation
- `jq . docs.json`
- `jq . config/navigation.json`
- `npx mint validate` *(fails in this environment on Node 25.8.2; Mintlify requires Node < 25)*
