### PR TITLE
docs(content): humanize homepage and customer path copy

### DIFF
--- a/customers/how-we-work.mdx
+++ b/customers/how-we-work.mdx
@@ -5,24 +5,20 @@ description: The practical model behind a Grounded Systems engagement.
 
 We work from inside the real environment.
 
-That means we do not build a polished answer at a distance and hand it over later. We work with the client team where the actual friction lives.
+That is more practical than it sounds. It means we join the work where the friction actually lives, with the people who already own the system, instead of building a polished answer somewhere else and hoping it lands.
 
-## Our model
+## How an engagement usually moves
 
-- embed in the work
-- understand the real constraints
-- make one safe move first
-- pair while shipping
-- reduce outside presence over time
-- leave with stronger client capability in place
+We start by understanding the real constraints: what cannot break, where ownership is fuzzy, and which seams keep slowing things down. Then we make one safe move in the existing system, not a grand redesign on a slide.
 
-## What we do not do
+From there, the work becomes shared. We pair while shipping, explain trade-offs in the open, and help the team build confidence in its own decisions. As that confidence grows, our role gets lighter on purpose. We move from doing, to pairing, to reviewing, to stepping back.
 
-- take hidden ownership
-- sell tool adoption as transformation
-- create dependency as a business model
-- confuse external motion with internal strength
+## What this should feel like
+
+A Grounded Systems engagement should feel practical, not theatrical. You should see progress inside the current system, clearer reasoning around decisions, and more confidence in the host team over time.
+
+You should not see hidden ownership, a surprise tool agenda, or an outside team quietly becoming the real delivery engine.
 
 ## Why this matters
 
-The strongest improvements are the ones a client can continue carrying after we step back.
+The strongest improvements are the ones a client can still carry when we are no longer in the room.

--- a/customers/what-we-help-with.mdx
+++ b/customers/what-we-help-with.mdx
@@ -7,29 +7,20 @@ Grounded Systems is built for situations where progress is needed, but the curre
 
 ## Typical situations
 
-We are useful when:
+Grounded Systems is most useful when the system still matters, but the current way of changing it keeps creating drag.
 
-- delivery is slowed by structural friction
-- ownership is unclear across teams
-- systems are hard to change safely
-- modernization keeps turning into parallel work and postponed migration
-- external delivery helps temporarily, but internal capability does not improve
+**Delivery is slower or riskier than it should be.** Teams are working hard, but every change feels heavier than it ought to.
 
-## What sits underneath these problems
+**Ownership is split or blurry.** Decisions bounce between teams, vendors, platforms, or approval paths, so the real problem never sits still long enough to get solved.
 
-The issue is often not one broken tool or one weak team.
+**Modernization keeps getting externalized.** The answer keeps becoming a separate track, a future migration, or an outside effort that helps for a while without improving the customer's own capability.
 
-More often, the real problem sits between:
+## What usually sits underneath
 
-- teams and neighboring teams
-- delivery and operations
-- systems and decision structures
-- speed pressure and ownership reality
+These problems rarely come from one weak team or one missing tool.
+
+More often, the friction sits in the seams: between delivery and operations, between systems and decision structures, or between the pressure to move fast and the reality of who can actually own the work.
 
 ## What we aim to improve
 
-- client capability
-- clearer ownership
-- safer movement inside the real system
-- less dependence on outside help
-- better conditions for continued modernization
+We aim to improve customer capability, clarify ownership, make change safer inside the real system, and leave better conditions for continued modernization after we step back.

--- a/customers/when-we-are-a-fit.mdx
+++ b/customers/when-we-are-a-fit.mdx
@@ -5,28 +5,16 @@ description: The conditions where Grounded Systems is likely to help, and where 
 
 This model is not meant to fit every engagement.
 
-## Good fit
+## When we are usually a strong fit
 
-We are usually a strong fit when:
+Grounded Systems works best when leadership wants stronger internal capability, not just short-term external throughput. The host team needs enough ownership to make delivery and operational decisions, and enough sponsor support to protect the work while it changes.
 
-- the client wants stronger internal capability
-- the host team can own backlog, decisions, and operations
-- modernization needs to happen inside active systems
-- there is enough sponsor support to protect the work
-- the environment has friction that cannot be solved by more output alone
+It is especially useful when modernization has to happen inside an active system and the real constraint cannot be solved by adding more output alone.
 
-## Weak fit
+## When we are usually a weak fit
 
-We are usually a weak fit when:
-
-- the real ask is short-term external throughput
-- ownership is absent or politically impossible
-- the team has no room to participate
-- the organization wants a tool rollout more than a capability shift
-- taper would be treated as failure
+It is a weak fit when the real ask is "please ship this for us" or when the team has no room to participate. It is also a weak fit when ownership is politically impossible, when a tool rollout is being treated as the answer, or when taper would be seen as failure rather than as the model working.
 
 ## Why we say this plainly
 
-Bad-fit work is expensive for both sides.
-
-Clarity early is better than a polished misunderstanding.
+Bad-fit work is expensive for both sides. A clear no early is better than a polished misunderstanding that turns into dependency later.

--- a/index.mdx
+++ b/index.mdx
@@ -38,22 +38,10 @@ Grounded Systems is a small senior consulting capability that embeds where work 
 
 ## What we help make possible
 
-- safer progress in systems that are already carrying real value
-- clearer ownership across teams, platforms, and decision paths
-- better technical and organizational judgment close to the work
-- less dependence on outside delivery over time
-- modernization that still holds after we leave
+This work helps teams make safer progress in systems that already carry real value. It brings ownership closer to the work, improves technical and organizational judgment, and reduces the need for outside delivery over time. The aim is not a burst of activity while we are present. It is modernization that still holds after we leave.
 
-## Why this model matters
+## Why this model feels different
 
-Many modernization efforts create movement without capability. A new platform appears. A parallel system gets built. An outside team ships improvements. The customer is still left depending on someone else to keep things moving.
+Many modernization efforts create movement first and capability later, if it arrives at all. A new platform appears. A parallel system gets built. Another team ships the change. The customer is still left depending on someone else to keep it moving.
 
-Grounded Systems takes a different approach. We help teams learn while shipping, make visible trade-offs, and strengthen the habits that let them continue on their own.
-
-## What makes this different
-
-- work happens inside the system that already carries value
-- customer ownership stays close to the real decisions
-- trade-offs stay visible instead of hiding behind process
-- outside help tapers instead of becoming permanent
-- progress is measured by retained capability, not activity volume
+Grounded Systems works the other way around. We help teams learn while shipping, keep trade-offs visible, and strengthen the habits that let them continue on their own.


### PR DESCRIPTION
## Summary
- apply the GRO-19 handoff copy updates to the highest-priority pages
- replace list-heavy sections with narrative flow in `index.mdx` and key customer pages
- keep wording aligned with Grounded Systems stance (ownership, modernization in place, taper)

## Files changed
- `index.mdx`
- `customers/how-we-work.mdx`
- `customers/what-we-help-with.mdx`
- `customers/when-we-are-a-fit.mdx`

## Notes
- `GROUNDING.md`, `COMMIT_POLICY.md`, and `PR_POLICY.md` were not present in this checkout; implementation followed the issue handoff document and existing repo conventions.