### PR TITLE
GRO-22: polish Mintlify chrome and landing hierarchy

### DIFF
--- a/cases/index.mdx
+++ b/cases/index.mdx
@@ -5,7 +5,9 @@ description: Practical examples that show where friction lives and how a grounde
 
 Cases make the model concrete.
 
-They show how Grounded Systems behaves when real systems, real constraints, and real organizational seams are involved. These are not polished success stories. They are working examples of where friction tends to hide, what the wrong move often looks like, and how a more grounded response can begin.
+<p className="gs-lead">
+  They show how Grounded Systems behaves when real systems, real constraints, and real organizational seams are involved. These are not polished success stories. They are working examples of where friction tends to hide, what the wrong move often looks like, and how a more grounded response can begin.
+</p>
 
 ## What the cases help you see
 
@@ -18,6 +20,7 @@ Use them to understand:
 
 ## Current cases
 
+<div className="gs-overview-band">
 <CardGroup cols={3}>
   <Card title="Legacy modernization" icon="wrench" href="/cases/legacy-modernization" cta="Read the case" arrow>
     Follow the shape of grounded change inside a system that already carries business value.
@@ -29,6 +32,7 @@ Use them to understand:
     Study the organizational and technical seams where platform choices often create new drag.
   </Card>
 </CardGroup>
+</div>
 
 ## How to read them
 

--- a/customers/index.mdx
+++ b/customers/index.mdx
@@ -5,7 +5,9 @@ description: What Grounded Systems helps with, how the model works, and when it 
 
 Grounded Systems is for organizations that need progress in systems they already rely on.
 
-This work fits best when modernization matters, but replacing everything, outsourcing the hard parts, or running a big parallel program would add more risk than clarity.
+<p className="gs-lead">
+  This work fits best when modernization matters, but replacing everything, outsourcing the hard parts, or running a big parallel program would add more risk than clarity.
+</p>
 
 ## Where we help most
 
@@ -35,6 +37,7 @@ The goal is not to become your delivery engine. The goal is to help your own tea
 
 ## Start with the right path
 
+<div className="gs-overview-band">
 <CardGroup cols={2}>
   <Card title="What we help with" icon="target" href="/customers/what-we-help-with" cta="See focus areas" arrow>
     See the kinds of delivery, ownership, and modernization problems this model is built to address.
@@ -46,6 +49,7 @@ The goal is not to become your delivery engine. The goal is to help your own tea
     Use the fit guidance to assess readiness, boundaries, and whether the conditions are right.
   </Card>
 </CardGroup>
+</div>
 
 ## When this is a strong fit
 

--- a/docs.json
+++ b/docs.json
@@ -6,7 +6,7 @@
   "colors": {
     "primary": "#111111"
   },
-  "logo": "/images/og-image.png",
+  "logo": "/images/logo-navbar.svg",
   "favicon": "/images/favicon.ico",
   "appearance": {
     "default": "light",

--- a/images/logo-navbar.svg
+++ b/images/logo-navbar.svg
@@ -1,0 +1,13 @@
+<svg width="460" height="72" viewBox="0 0 460 72" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="gsLogoTitle gsLogoDesc">
+  <title id="gsLogoTitle">Grounded Systems</title>
+  <desc id="gsLogoDesc">Grounded Systems wordmark with a rooted mark</desc>
+  <g>
+    <circle cx="28" cy="24" r="9" fill="#111111"/>
+    <path d="M28 33V55" stroke="#111111" stroke-width="4" stroke-linecap="round"/>
+    <path d="M28 44L17 55" stroke="#111111" stroke-width="4" stroke-linecap="round"/>
+    <path d="M28 44L39 55" stroke="#111111" stroke-width="4" stroke-linecap="round"/>
+    <path d="M20 18C21 13 24 10 28 10C32 10 35 13 36 18" stroke="#111111" stroke-width="3" stroke-linecap="round"/>
+  </g>
+  <text x="58" y="31" fill="#111111" font-family="'Source Sans 3', sans-serif" font-size="26" font-weight="700" letter-spacing="0.4">Grounded</text>
+  <text x="58" y="56" fill="#111111" font-family="'Source Sans 3', sans-serif" font-size="24" font-weight="600" letter-spacing="0.3">Systems</text>
+</svg>

--- a/index.mdx
+++ b/index.mdx
@@ -5,7 +5,9 @@ description: Modernize from within, with a small senior team that helps yours ma
 
 Grounded Systems helps organizations modernize from within.
 
-We work inside the real system, with the people who already own it, so change becomes safer, clearer, and easier to carry forward.
+<p className="gs-lead">
+  We work inside the real system, with the people who already own it, so change becomes safer, clearer, and easier to carry forward.
+</p>
 
 ## What this looks like
 
@@ -15,6 +17,7 @@ Grounded Systems is a small senior consulting capability that embeds where work 
 
 ## Start where you fit
 
+<div className="gs-overview-band">
 <CardGroup cols={2}>
   <Card title="For customers" icon="building-2" href="/customers/index" cta="See customer fit" arrow>
     Understand where this model fits, how the work behaves, and what good clients should expect.
@@ -35,6 +38,7 @@ Grounded Systems is a small senior consulting capability that embeds where work 
     Use the glossary, FAQ, and contribution guidance when you need stable definitions and direct answers.
   </Card>
 </CardGroup>
+</div>
 
 ## What we help make possible
 

--- a/playbook/index.mdx
+++ b/playbook/index.mdx
@@ -5,7 +5,9 @@ description: Practical guidance for entering, navigating, and exiting real moder
 
 The playbook turns the stance into practical moves.
 
-It is not a fixed method and it is not a bag of rituals. It is a working guide for entering real environments, reading what is happening, and making decisions that help the customer move without creating new dependency.
+<p className="gs-lead">
+  It is not a fixed method and it is not a bag of rituals. It is a working guide for entering real environments, reading what is happening, and making decisions that help the customer move without creating new dependency.
+</p>
 
 ## What you will find here
 
@@ -26,6 +28,7 @@ The goal is not to copy visible practices from page to page. The goal is to make
 
 ## Start with the right move
 
+<div className="gs-overview-band">
 <CardGroup cols={2}>
   <Card title="Entry gate" icon="door-open" href="/playbook/entry-gate" cta="Run entry checks" arrow>
     Use the entry checks to decide whether the work should begin at all.
@@ -46,6 +49,7 @@ The goal is not to copy visible practices from page to page. The goal is to make
     Keep the engagement moving toward lower dependence instead of permanent presence.
   </Card>
 </CardGroup>
+</div>
 
 ## The anchor question
 

--- a/practitioners/index.mdx
+++ b/practitioners/index.mdx
@@ -5,7 +5,9 @@ description: What this work asks of the people doing it, and who tends to thrive
 
 This work is for practitioners who can enter a real environment, understand what is actually happening, and help a team move without taking over.
 
-It suits people who care about systems, judgment, and the quiet work of making others more capable.
+<p className="gs-lead">
+  It suits people who care about systems, judgment, and the quiet work of making others more capable.
+</p>
 
 ## The kind of practitioner who tends to fit
 
@@ -26,6 +28,7 @@ It asks for timing, restraint, pattern recognition, and the ability to help team
 
 ## Explore the practitioner path
 
+<div className="gs-overview-band">
 <CardGroup cols={2}>
   <Card title="Who thrives here" icon="user-round-check" href="/practitioners/who-thrives-here" cta="See the profile" arrow>
     Get more specific about the traits and operating habits that make this work sustainable.
@@ -37,6 +40,7 @@ It asks for timing, restraint, pattern recognition, and the ability to help team
     Read the practical bar for judgment, restraint, and delivery integrity in the field.
   </Card>
 </CardGroup>
+</div>
 
 ## Why this matters
 

--- a/principles/index.mdx
+++ b/principles/index.mdx
@@ -5,7 +5,9 @@ description: The principles that shape how Grounded Systems makes decisions and 
 
 These principles exist to keep the work clear when pressure rises.
 
-They are not slogans. They are practical constraints that protect customer ownership, keep modernization grounded in the real system, and reduce the chance that good intent turns into dependency.
+<p className="gs-lead">
+  They are not slogans. They are practical constraints that protect customer ownership, keep modernization grounded in the real system, and reduce the chance that good intent turns into dependency.
+</p>
 
 ## The principles
 
@@ -19,6 +21,7 @@ They are not slogans. They are practical constraints that protect customer owner
 
 ## Explore the principle set
 
+<div className="gs-overview-band">
 <CardGroup cols={2}>
   <Card title="Core principles" icon="badge-check" href="/principles/core-principles" cta="See the full set" arrow>
     Read the full stance in a tighter summary of what Grounded Systems protects and why.
@@ -33,6 +36,7 @@ They are not slogans. They are practical constraints that protect customer owner
     Connect the principles to the expectations placed on the people doing the work.
   </Card>
 </CardGroup>
+</div>
 
 ## Why these principles matter
 

--- a/reference/index.mdx
+++ b/reference/index.mdx
@@ -5,7 +5,9 @@ description: Stable definitions, direct answers, and guidance that keeps the sit
 
 The reference section holds the stable material that supports the rest of the site.
 
-Use it when you need a precise definition, a direct answer, or guidance on how the documentation should evolve without losing its shape.
+<p className="gs-lead">
+  Use it when you need a precise definition, a direct answer, or guidance on how the documentation should evolve without losing its shape.
+</p>
 
 ## What belongs here
 
@@ -15,6 +17,7 @@ Use it when you need a precise definition, a direct answer, or guidance on how t
 
 ## Start here
 
+<div className="gs-overview-band">
 <CardGroup cols={3}>
   <Card title="Glossary" icon="book-a" href="/reference/glossary" cta="Open glossary" arrow>
     Use the stable definitions that keep the language precise across the site.
@@ -26,3 +29,4 @@ Use it when you need a precise definition, a direct answer, or guidance on how t
     Follow the guidance for growing the documentation without losing coherence.
   </Card>
 </CardGroup>
+</div>

--- a/style.css
+++ b/style.css
@@ -2,6 +2,7 @@
   --gs-chrome-shadow: 0 10px 28px rgba(17, 17, 17, 0.08);
   --gs-border-muted: rgba(17, 17, 17, 0.1);
   --gs-surface-soft: linear-gradient(180deg, rgba(17, 17, 17, 0.03) 0%, rgba(17, 17, 17, 0.01) 100%);
+  --gs-surface-band: linear-gradient(180deg, rgba(17, 17, 17, 0.055) 0%, rgba(17, 17, 17, 0.015) 100%);
   --gs-space-vertical: clamp(2.5rem, 2rem + 1vw, 3.5rem);
 }
 
@@ -20,8 +21,37 @@
   padding: 0.32rem 0.7rem;
 }
 
+#navbar img {
+  max-height: 1.9rem;
+  width: auto;
+}
+
 #content-area {
   padding-top: var(--gs-space-vertical);
+}
+
+.gs-lead {
+  font-size: clamp(1.04rem, 0.96rem + 0.35vw, 1.26rem);
+  line-height: 1.55;
+  max-width: 70ch;
+  margin-bottom: 1.3rem;
+}
+
+.gs-overview-band {
+  margin: 1.7rem 0 2rem;
+  padding: clamp(0.9rem, 0.8rem + 0.5vw, 1.35rem);
+  border: 1px solid var(--gs-border-muted);
+  border-radius: 18px;
+  background: var(--gs-surface-band);
+}
+
+.gs-overview-band .card {
+  border-color: rgba(17, 17, 17, 0.13);
+}
+
+.gs-overview-band .card:first-child {
+  border-color: rgba(17, 17, 17, 0.25);
+  box-shadow: 0 12px 28px rgba(17, 17, 17, 0.07);
 }
 
 .card {
@@ -49,4 +79,15 @@
 .toc {
   border-left: 1px solid var(--gs-border-muted);
   padding-left: 1rem;
+}
+
+@media (max-width: 768px) {
+  #content-area {
+    padding-top: 2rem;
+  }
+
+  .gs-overview-band {
+    padding: 0.82rem;
+    margin: 1.1rem 0 1.55rem;
+  }
 }


### PR DESCRIPTION
## Summary
- switch navbar logo from OG image to a dedicated small-format brand wordmark
- add restrained landing-page hierarchy polish (`gs-lead`, `gs-overview-band`) for homepage and top-level section pages
- tune card emphasis and mobile spacing to reduce template sameness while staying within Mintlify defaults

## Files
- `docs.json`
- `style.css`
- `index.mdx`
- `customers/index.mdx`
- `practitioners/index.mdx`
- `principles/index.mdx`
- `playbook/index.mdx`
- `cases/index.mdx`
- `reference/index.mdx`
- `images/logo-navbar.svg`

## Validation
- `npx mint validate` *(blocked: local Node is v25.8.2; Mintlify CLI requires Node < 25)*