### PR TITLE
docs: humanize interior guidance pages (GRO-24)

### DIFF
--- a/playbook/checklists.mdx
+++ b/playbook/checklists.mdx
@@ -5,9 +5,11 @@ description: Lightweight checklists for entering, navigating, and exiting an eng
 
 These checklists are not a substitute for judgment.
 
-They exist to make the obvious visible before it becomes expensive.
+Use them to catch predictable misses early, especially when pressure is high and teams are moving quickly.
 
 ## Entry checklist
+
+Use this before starting work to confirm the environment can support customer ownership from day one.
 
 - The host team owns real work
 - The sponsor wants capability, not just output
@@ -18,6 +20,8 @@ They exist to make the obvious visible before it becomes expensive.
 
 ## Early engagement checklist
 
+Use this in the first weeks to confirm the work is grounded in real constraints and not drifting into theater.
+
 - One real pressure point has been identified
 - One safe first move is visible
 - Ownership seams are mapped
@@ -27,6 +31,8 @@ They exist to make the obvious visible before it becomes expensive.
 
 ## Drift checklist
 
+Use this during delivery to detect dependency drift before it becomes normal.
+
 - Are we becoming the real delivery center?
 - Is the client team still making key decisions?
 - Are we adding structure faster than we are reducing friction?
@@ -35,9 +41,13 @@ They exist to make the obvious visible before it becomes expensive.
 
 ## Exit checklist
 
+Use this before stepping back to confirm independence is visible in behavior, not only in intent.
+
 - The team can move without prompting
 - The team owns delivery and operations
-- Trade-offs are explained in the team’s own words
+- Trade-offs are explained in the team's own words
 - Seams are being handled directly by the client team
 - Remaining friction is visible and documented
 - A return, if needed, would be brief and specific
+
+Judgment always overrides the checklist when context requires it.

--- a/playbook/decision-patterns.mdx
+++ b/playbook/decision-patterns.mdx
@@ -3,113 +3,67 @@ title: Decision patterns
 description: Practical decision habits for making useful moves under real constraints.
 ---
 
-This model depends on decision quality more than decision theater.
+Decision patterns are here to support judgment when the work is messy and the pressure to sound certain is high.
 
-The point is not to look rigorous. The point is to make moves that reduce friction, protect ownership, and leave the client better able to keep moving afterward.
+In this model, a good decision is not the most impressive one. It is the one that reduces friction, protects ownership, and makes the next move easier to carry.
 
-## Start with the real constraint
+## Find the real constraint first
 
-Do not begin with the most visible symptom.
+Most bad decisions start by treating the loudest symptom as the problem. Start by locating what repeatedly slows the system down, then decide from that point instead of from surface noise.
 
-Ask:
+Useful prompts:
 
-- what is actually making this hard?
-- where does the work really slow down?
-- is this a team problem, a seam problem, or a structural problem?
-- what would still be true if we removed the current symptom?
+- What is actually making this hard?
+- Where does progress stall repeatedly?
+- Is this local execution pain, or a seam between teams?
+- What would still be true if this symptom disappeared tomorrow?
 
-A clean symptom description is not the same thing as a useful problem definition.
+## Choose moves that are safe to learn from
 
-## Prefer moves that lower the cost of being wrong
+When the environment is uncertain, a reversible move teaches faster than a heavy solution. Favor steps that create evidence quickly without locking the organization into high-cost commitments.
 
 A good move is often one that is:
 
 - safe to try
 - cheap to reverse
 - small enough to learn from quickly
-- useful even if it is not the final answer
+- still useful even if it is not the final answer
 
-Heavy solutions often try to buy certainty up front. That usually creates more cost than confidence.
+## Simplify before you add
 
-## Simplify before adding
+Extra structure can look responsible while quietly increasing ownership burden. Before adding layers, check whether the current path can be clarified, reduced, or made easier to operate.
 
-Before introducing a new layer, ask:
+Ask:
 
-- can this be removed instead?
-- can the current path be clarified rather than replaced?
-- can an existing tool or workflow be used more cleanly?
-- are we adding structure because it helps, or because it looks responsible?
-
-A simpler system is usually easier to own, easier to explain, and easier to recover.
+- Can we remove friction instead of adding process?
+- Can we improve an existing tool before introducing another one?
+- Will this be easier to own at 02:00?
 
 ## Follow ownership before tooling
 
-If ownership is unclear, tooling decisions are premature.
+Tooling choices made before ownership choices usually become delayed problems. Decide who carries decisions, operations, and explanation first, then pick tooling that fits that reality.
 
-Ask:
+If ownership is unclear, pause the tooling decision.
 
-- who will own this after we leave?
-- who will operate it when it fails?
-- who will explain why it exists six months from now?
-- does this fit the current organizational boundaries?
+## Let seams change the decision
 
-A good tool in the wrong ownership context becomes a delayed problem.
+Cross-team seams are part of the system, not side context. A decision that looks correct inside one team can fail quickly if the seam is unresolved.
 
-## Treat seams as first-class
+Check early whether the bottleneck is between teams, whether words mean the same thing on both sides, and whether "not supported" is hiding an unworked interface.
 
-When work crosses teams, the seam is part of the system.
+## Use early progress to prove something real
 
-Do not localize a cross-team problem too early.
+Early wins matter when they prove that the client team can move from inside the current system. The point is traction that teaches, not visible motion that impresses.
 
-Ask:
+A useful first move should show that:
 
-- is the bottleneck inside the team, or between teams?
-- are responsibilities clear on both sides?
-- are different groups using the same words differently?
-- is “not supported” masking an unworked interface?
-
-Many slow systems are really slow seams.
-
-## Use visible progress as proof, not theater
-
-Early movement matters, but it should prove something real.
-
-A good first move should show that:
-
-- the client team can participate directly
-- the current system can be improved from within
-- the dependency is reducible
+- the client team is participating directly
+- dependency can be reduced in practice
 - the next move is now easier than before
-
-The point is not to impress. The point is to establish traction that teaches.
-
-## Know when not to decide yet
-
-Not deciding immediately can be the right move when:
-
-- ownership is still unclear
-- the system is still being misunderstood
-- the organization has not surfaced the real trade-off
-- a fast answer would lock in the wrong framing
-
-Delay is only useful when it protects better judgment, not when it hides avoidance.
 
 ## Useful default questions
 
-When in doubt, ask:
-
-- Will this make the client more capable after we leave?
-- Will this reduce future dependence or deepen it?
-- Will this be easier to own at 02:00?
+- Will this leave the client more capable after we leave?
+- Does this reduce future dependence or deepen it?
 - Are we improving the real system or building around it?
-- Is this move clarifying the work or decorating it?
-
-## What good decisions feel like
-
-Good decisions in this model often feel:
-
-- smaller than expected
-- clearer than impressive
-- easier to explain in plain language
-- more grounded in ownership than abstraction
-- more useful in practice than elegant on a slide
+- Is this choice clarifying the work or decorating it?

--- a/playbook/discovery.mdx
+++ b/playbook/discovery.mdx
@@ -3,64 +3,34 @@ title: Discovery
 description: How to understand the real shape of the environment before acting.
 ---
 
-Discovery is not a workshop ritual.
+Discovery is the work of understanding the real environment before prescribing changes to it.
 
-It is the work of understanding where the system actually resists change, where ownership really lives, and what the organization is quietly optimizing for.
+It is how you learn where change gets stuck, who carries the real risk, what cannot break, and what the organization is quietly optimizing for beneath the official story.
 
-## What to learn early
+## Find where friction keeps repeating
 
-### 1. Where friction lives
+Look for repeated delays, fragile handoffs, and decision loops that never close. The repeated pattern usually matters more than any single incident.
 
-Look for:
+## Map real ownership, not declared ownership
 
-- repeated delays
-- fragile handoffs
-- hard-to-change systems
-- unclear operational boundaries
-- decisions that keep being postponed
+Org charts describe formal responsibility, but delivery pressure exposes real ownership. Watch who people wait for when work stalls and who carries consequences when something fails.
 
-### 2. Where ownership lives
+## Learn what the system will protect
 
-Ask:
+Every environment protects something, even when no one names it directly. Those protections may be operational, political, regulatory, or reputational, and they shape what change is realistically possible.
 
-- who owns backlog
-- who owns operations
-- who can approve change
-- who people wait for when work stalls
-- who carries the real risk when things go wrong
+## Separate different meanings of success
 
-### 3. What cannot break
+Sponsors, delivery teams, platform groups, and managers often use the same word for different outcomes. Clarifying those differences early prevents false alignment and late friction.
 
-Every environment has guardrails, whether stated clearly or not.
-
-Find:
-- operational constraints
-- political constraints
-- compliance boundaries
-- customer-facing risk
-- unstated sacred ground
-
-### 4. What success means to different people
-
-Different actors often mean different things by “progress.”
-
-The sponsor may want confidence.
-A team lead may want flow.
-A platform team may want safety.
-A manager may want predictability.
-
-If these meanings stay blended together, the work will drift.
-
-## Good discovery questions
+## Useful discovery questions
 
 - What is hard here that should not be this hard?
 - Where does work slow down repeatedly?
-- What does the team need from outsiders in order to move?
-- What would still be fragile if we improved delivery speed tomorrow?
+- What still depends on outsiders for routine movement?
+- What would stay fragile even if throughput improved next month?
 - What would make this team less dependent six months from now?
 
-## Anti-pattern
+## Failure mode to avoid
 
-Bad discovery jumps too fast to solution shape.
-
-If the tooling conversation is stronger than the ownership conversation, the work is already leaning the wrong way.
+Bad discovery jumps from symptom to solution shape too quickly. If the tooling discussion becomes clearer than the ownership discussion, discovery is not complete.

--- a/playbook/field-signals.mdx
+++ b/playbook/field-signals.mdx
@@ -3,62 +3,56 @@ title: Field signals
 description: Weak signals that reveal how the environment actually works.
 ---
 
-Real conditions usually show themselves before people describe them clearly.
+Field signals are the small clues that tell you how the environment really works before anyone describes it clearly.
 
-These signals help reveal what the system is actually saying underneath the formal narrative.
+They matter because systems reveal themselves through behavior first: who waits, who decides, where the room goes quiet, and what gets treated as untouchable.
 
-## Signals of ownership
+## Ownership signals
 
-Look for:
+Ownership is visible in who can move work without escalation and who can explain trade-offs in plain language. Weak ownership often hides behind polite coordination.
+
+Watch for:
 
 - who makes decisions without escalation
-- who people wait for when something gets stuck
-- who explains the why behind changes
-- whether operational responsibility is clear at 02:00
+- who people wait for when work stalls
+- whether operational accountability is clear at 02:00
 
-Weak ownership often hides behind polite language.
+## Misalignment signals
 
-## Signals of misalignment
+Misalignment usually appears as smooth language with inconsistent behavior underneath. People may agree publicly while carrying different definitions privately.
 
-Look for:
+Watch for:
 
-- quick agreement without real follow-up questions
-- repeated use of the same words with different meanings
-- silence when responsibility is mentioned
-- energy drop around certain topics
+- repeated terms used with different meanings
+- silence when responsibility is named
+- energy drops around certain handoffs
 
-Misalignment often appears as smooth language covering structural uncertainty.
+## Dependency signals
 
-## Signals of dependency
+Dependency is often visible before anyone names it. The pattern is that movement depends on specialist mediation instead of routine team capability.
 
-Look for:
+Watch for:
 
-- “only X knows that”
-- “we need Y before we can continue”
-- the outside unit being treated as the real mover
-- work slowing down sharply when key people step back
+- "only X knows that"
+- sharp slowdown when one outside actor is unavailable
+- work that cannot proceed without external interpretation
 
-Dependency is often visible before anyone names it.
+## Tool-first signals
 
-## Signals of tool-first thinking
+Tool-first thinking appears when solution shape outruns understanding of the current system. This often increases load before it reduces friction.
 
-Look for:
+Watch for:
 
-- proposed platforms before the problem is grounded
-- new tooling framed as the main solution
-- little curiosity about existing systems and constraints
-- ownership questions postponed until later
+- platform choices proposed before constraints are clear
+- ownership questions deferred until after tooling decisions
+- low curiosity about current workflows and boundaries
 
-This usually means the conversation is too early or pointed in the wrong direction.
+## Capability-growth signals
 
-## Signals of genuine capability growth
+Genuine growth shows up when the client team is carrying more judgment directly, not only producing more output.
 
-Look for:
+Watch for:
 
-- the client team making trade-offs in its own words
-- direct conversations with neighboring teams
-- improvements continuing without prompting
-- practitioners simplifying rather than decorating
-- new people being taught the reasoning, not just the routine
-
-These are stronger signs than output volume.
+- trade-offs explained in the client team's own words
+- seam conversations handled directly across teams
+- simplification choices made without outside prompting

--- a/principles/anti-patterns.mdx
+++ b/principles/anti-patterns.mdx
@@ -3,90 +3,90 @@ title: Anti-patterns
 description: The recurring traps Grounded Systems is designed to reject.
 ---
 
-These are the recurring ways modernization work becomes expensive, fragile, or misleading.
+Anti-patterns matter because the wrong modernization move often looks sensible before its cost becomes visible.
 
-They matter because they often look like progress early on.
+Most traps promise speed, certainty, or cleanliness up front. The long-term cost is usually more dependency, blurrier ownership, or harder recovery.
 
 ## Feature factory drift
 
-This happens when the outside unit becomes valued mainly for shipping output.
+This trap appears when outside contributors become valued mainly for output volume and the client team quietly shifts from owner to requester.
 
-### Signals
+It is attractive because visible throughput creates quick confidence for sponsors.
 
-- the client stops participating deeply
-- outside people become the delivery center
-- progress depends more on external effort than internal growth
+Watch for:
 
-### Consequence
+- outside contributors treated as the delivery center
+- client participation thinning out over time
+- success measured only in shipped volume
 
-Movement may increase, but client capability does not.
+The cost is simple: movement increases, but client capability does not.
 
 ## Modernize elsewhere, migrate later
 
-This happens when change begins by building a separate future-state world and promising migration later.
+This trap appears when teams build a cleaner parallel world first and postpone integration with the live system.
 
-### Signals
+It is attractive because it feels technically cleaner and easier to narrate.
 
-- heavy future-state diagrams
-- weak connection to current operational reality
-- rising handover and migration burden
+Watch for:
 
-### Consequence
+- future-state architecture dominating current-state work
+- thin links to operational constraints
+- migration complexity deferred as a later problem
 
-A second problem space is created before the first one is improved.
+The cost is a second problem space before the first one is improved.
 
 ## Premature tooling
 
-This happens when tools are introduced before ownership, context, and friction are properly understood.
+This trap appears when tools become the center of the plan before ownership and constraints are grounded.
 
-### Signals
+It is attractive because tools provide fast structure and visible direction.
 
-- the tool becomes the story
-- local skills and current platforms are ignored
-- ownership questions are deferred
+Watch for:
 
-### Consequence
+- tooling decisions ahead of ownership decisions
+- low attention to existing system behavior
+- context questions postponed until implementation
 
-The organization inherits new load without reducing the real constraint.
+The cost is inherited complexity without relief on the real bottleneck.
 
 ## No-exit consulting
 
-This happens when there is no credible taper path.
+This trap appears when there is no credible taper path and outside presence remains structurally central.
 
-### Signals
+It is attractive because continuous support feels safer than designing independence.
 
-- the client still waits for outside decisions
-- routines pause when the outside unit steps back
-- taper keeps slipping without clear cause
+Watch for:
 
-### Consequence
+- routines pause when outside actors step back
+- taper repeatedly delayed without a clear reason
+- client teams waiting for outside judgment on routine calls
 
-Dependency becomes the product.
+The cost is dependency becoming the product.
 
 ## Local success sold as systemic change
 
-This happens when one improved team is used as proof that the wider organization has transformed.
+This trap appears when one strong local win is used as proof that the wider organization has transformed.
 
-### Signals
+It is attractive because success stories are easier than replication work.
 
-- success stories detached from replication
-- no evidence that conditions are being reproduced elsewhere
-- local movement turned into broad narrative
+Watch for:
 
-### Consequence
+- broad claims supported by one team example
+- no evidence of repeatable conditions elsewhere
+- narrative scale greater than operational scale
 
-False confidence hides the real scale of the problem.
+The cost is false confidence masking unresolved system constraints.
 
 ## Ritual imitation without ownership
 
-This happens when teams copy visible practices without internalizing the reasoning behind them.
+This trap appears when teams copy visible practices but do not internalize the reasoning behind them.
 
-### Signals
+It is attractive because visible form is faster to copy than judgment.
 
-- ceremonies survive, but judgment does not
-- language is copied, but trade-offs remain implicit
-- teams revert under pressure
+Watch for:
 
-### Consequence
+- ceremonies retained while trade-offs stay implicit
+- language copied without behavioral change
+- quick reversion under pressure
 
-The form survives, but the capability does not.
+The cost is a process-shaped shell with no durable capability inside it.

--- a/principles/engagement-model.mdx
+++ b/principles/engagement-model.mdx
@@ -3,65 +3,44 @@ title: Engagement model
 description: How Grounded Systems enters, works, tapers, and exits.
 ---
 
-Grounded Systems is not a delivery wrapper. It is a temporary embedded model designed to strengthen client capability from inside the work.
+The engagement model is simply the normal motion of the work.
+
+We enter where friction is real, make one useful move inside the current system, help the team strengthen its own judgment while shipping, work seams directly when they matter, and then reduce our role on purpose.
 
 ## The basic shape
 
-A small senior unit embeds where progress is stuck.
-
-The unit works with the client team inside the current system, helps unlock safe movement, transfers judgment and working patterns, then reduces its presence over time.
+A small senior unit embeds with the client team inside the existing environment. The unit does real work in public, transfers judgment through shared delivery, and keeps customer ownership visible from day one.
 
 ## The sequence
 
-### 1. Enter
+### Enter
 
-Start where there is real friction and real ownership.
+Start where friction is real and ownership is close enough to work directly. Early work focuses on reading constraints, risks, and decision boundaries before prescribing structure.
 
-The first job is to understand:
-- where progress is blocked
-- who owns what
-- what cannot break
-- what the client thinks success means
+### Ignite
 
-### 2. Ignite
+Make one small, safe move that improves the current system now. This establishes practical trust and shows progress without creating a parallel modernization track.
 
-Make one small, safe improvement inside the current system.
+### Enable while shipping
 
-The point is not speed for its own sake. The point is to prove that movement is possible without building a parallel world.
+Use active delivery as the teaching surface. Decisions, incidents, pull requests, and seam conversations are where capability transfer happens.
 
-### 3. Enable while shipping
+### Bridge seams
 
-Pair on real work.
+When cross-team boundaries are the bottleneck, work the seam directly. Clarify interface ownership and reduce recurring handoff friction instead of escalating theater.
 
-Use actual decisions, trade-offs, pull requests, incidents, and handoffs as the teaching surface. The client should operate, merge, and carry the work from day one.
+### Taper
 
-### 4. Bridge seams
+Reduce outside involvement deliberately by shifting from doing, to pairing, to reviewing, to advising. The center of gravity should move toward the client team throughout this phase.
 
-When another team is part of the bottleneck, work that seam directly.
+### Exit
 
-That may include platform, security, architecture, compliance, or neighboring delivery teams. The goal is to resolve real friction, not to create escalations as theater.
-
-### 5. Taper
-
-Reduce the outside role gradually.
-
-Shift from doing, to pairing, to reviewing, to advising.
-
-### 6. Exit
-
-Leave when independence is visible and stable enough to carry forward.
+Exit when the client team can continue with stable judgment and visible ownership. The target is temporary presence and lasting capability, not perfect conditions.
 
 ## Boundaries
 
-This model does not work when:
-
-- the client team cannot own the result
-- the sponsor mainly wants external throughput
-- the outside unit is treated as the real delivery team
-- taper is politically impossible
+This model is a poor fit when the client cannot own the result, when the sponsor wants external throughput as the main outcome, or when taper is structurally impossible.
 
 ## What success looks like
 
-The strongest success signal is simple:
-
-The client team can continue moving without us.
+Success is visible when the client team keeps moving without outside prompting, explains trade-offs in its own words, and resolves seams directly with neighboring groups.

--- a/reference/faq.mdx
+++ b/reference/faq.mdx
@@ -5,48 +5,44 @@ description: Common questions about the Grounded Systems model.
 
 ## Is this staff augmentation?
 
-No.
+No. The model does not add outside capacity as the end goal.
 
-The aim is not to extend a client team with outside capacity. The aim is to strengthen the client team’s own capability and reduce dependence over time.
+The goal is to strengthen the client team's own capability so progress continues without long-term external dependence.
 
 ## Is delivery part of the model?
 
-Yes, but not as the main product.
+Yes, but delivery is the medium, not the main product.
 
-Delivery is often the medium through which learning, ownership, and better judgment are transferred.
+Real delivery work is where ownership, trade-off quality, and operating judgment are transferred.
 
 ## Does this only apply to technology?
 
-No.
+No. Technical systems matter, but organizational structure often drives the hardest constraints.
 
-Technical systems matter, but many of the hardest constraints are organizational. Ownership boundaries, workflows, approvals, and incentives often shape progress more than the tooling itself.
+Ownership boundaries, approval paths, workflows, and incentives usually shape outcomes as much as tooling choices.
 
 ## Do you prescribe tools or frameworks?
 
-No.
+No. Tools follow context.
 
-Tools follow context. A tool is useful only if it fits the environment, reduces friction, and can be owned properly afterward.
+A tool is useful only when it fits the real environment, reduces friction, and can be owned clearly after we step back.
 
 ## How small is the embedded unit?
 
-Usually small enough to stay coherent and senior enough to carry judgment well.
+Usually small enough to stay coherent and senior enough to carry judgment across technical and organizational seams.
 
 ## How do you measure success?
 
-The strongest signals are:
+The primary signal is independence that lasts after exit: the client team keeps moving and making sound decisions without outside prompting.
 
-- more client independence
-- clearer ownership
-- better local decision-making
-- less outside dependency
-- continued movement after we step back
+Supporting signals include clearer ownership, stronger local decision quality, reduced dependency, and continued movement after we step back.
 
 ## What happens after exit?
 
-The client team continues carrying the work.
+The client team continues carrying the work directly.
 
-If a new blocker appears later, a short return may help, but the goal remains the same: unblock, strengthen, and step back again.
+If a new blocker appears later, a short return can help, but the purpose stays the same: unblock, strengthen capability, and step back again.
 
 ## When should this model not be used?
 
-It should not be used when the client cannot own the result, when the real ask is external throughput, or when taper would be treated as failure.
+Do not use it when the client cannot own the result, when the real ask is external throughput, or when taper would be treated as failure.

--- a/reference/glossary.mdx
+++ b/reference/glossary.mdx
@@ -3,11 +3,13 @@ title: Glossary
 description: Plain-language definitions for recurring Grounded Systems terms.
 ---
 
+These definitions keep language consistent across the site and reduce accidental drift in how the model is described.
+
 | Term | Definition |
 | --- | --- |
-| Capability | The client team’s practical ability to understand, change, operate, and improve its own system. |
+| Capability | The client team's practical ability to understand, change, operate, and improve its own system. |
 | Customer ownership | The condition where the client team owns goals, backlog, decisions, delivery, and operations. |
-| Dependency | A state where the client team relies on outside people to make progress or keep things working. A state where progress or decision-making still relies on outside people to keep moving. |
+| Dependency | A state where progress or decision-making still relies on outside people to keep moving. |
 | Embedded work | Working with the client team inside its actual systems, constraints, and day-to-day reality. |
 | Exit | The deliberate reduction and removal of outside presence once client independence is visible enough to carry forward. |
 | Friction | Anything in the system or organization that makes useful progress harder than it should be. |


### PR DESCRIPTION
## Summary\nThis PR applies the GRO-24 content handoff by reducing list-heavy structure and making interior pages explanation-first while preserving page roles.\n\n## What changed\n- Rewrote prose flow in core playbook pages to explain the why before support lists\n- Refactored principles pages away from mechanical list patterns\n- Added light framing to checklist/reference pages while keeping structured formats where appropriate\n- Fixed glossary Dependency duplication and added glossary framing line\n\n## Files\n- playbook/decision-patterns.mdx\n- playbook/discovery.mdx\n- playbook/field-signals.mdx\n- playbook/checklists.mdx\n- principles/anti-patterns.mdx\n- principles/engagement-model.mdx\n- reference/faq.mdx\n- reference/glossary.mdx\n\n## Validation\n- Verified config/navigation.json page references all resolve (pages=31 missing=0)\n\nCloses GRO-24.