### PR TITLE
docs(content): complete remaining GRO-29 handoff updates

### DIFF
--- a/cases/index.mdx
+++ b/cases/index.mdx
@@ -3,17 +3,19 @@ title: Cases
 description: Practical examples that show where friction lives and how a grounded response begins.
 ---
 
-<div className="gs-hub-page" />
+The cases show how the model behaves when real constraints and organizational seams are involved. They make the stance concrete by showing where friction lives, what the wrong move looks like, and how a grounded response begins.
 
-Cases make the model concrete.
+## What the cases help you see
 
-<p className="gs-lead">
-  They show how Grounded Systems behaves when real systems, real constraints, and real organizational seams are involved. These are not polished success stories. They are working examples of where friction tends to hide, what the wrong move often looks like, and how a more grounded response can begin.
-</p>
+Use them to understand:
+
+- where the real constraint often lives
+- what kind of first move lowers risk and increases clarity
+- which forms of drift or dependency need to be avoided
+- what capability should remain after the intervention
 
 ## Current cases
 
-<div className="gs-overview-band">
 <CardGroup cols={3}>
   <Card title="Legacy modernization" icon="wrench" href="/cases/legacy-modernization" cta="Read the case" arrow>
     Follow the shape of grounded change inside a system that already carries business value.
@@ -25,13 +27,12 @@ Cases make the model concrete.
     Study the organizational and technical seams where platform choices often create new drag.
   </Card>
 </CardGroup>
-</div>
 
-## Case-reading lenses
+## How to read them
 
-<div className="gs-chip-row" role="list" aria-label="Case reading lenses">
-  <span role="listitem">Constraint</span>
-  <span role="listitem">Ownership</span>
-  <span role="listitem">Move</span>
-  <span role="listitem">Carry forward</span>
-</div>
+A useful case should help answer four questions:
+
+- what was actually hard
+- where ownership lived
+- what move reduced friction
+- what the team could carry forward afterward

--- a/cases/legacy-modernization.mdx
+++ b/cases/legacy-modernization.mdx
@@ -11,44 +11,19 @@ That usually creates two problems instead of improving one.
 
 ## The real constraint
 
-The constraint is rarely age alone.
-
-More often, it is a mix of:
-
-- embedded business logic
-- unclear ownership seams
-- operational fragility
-- fear of breaking what still carries value
-- long-standing habits around change
+The real constraint is rarely age alone. Legacy systems often carry embedded business logic, operating habits, and risk memory that teams depend on even when it is poorly documented.
 
 ## The wrong move
 
-The wrong move is to treat the existing system as waste and begin by externalizing the work.
-
-This often creates:
-
-- duplicated effort
-- migration burden
-- new ownership confusion
-- more architecture on paper than movement in reality
+The wrong move is to treat the existing system as waste and begin by externalizing the work. That usually creates duplicated effort, migration burden, and new ownership confusion before the original system is meaningfully improved.
 
 ## The grounded move
 
-Start inside the active system.
-
-Look for one safe improvement that:
-
-- reduces friction now
-- does not depend on a parallel platform
-- teaches the team something useful
-- lowers the next cost of change
+Start inside the active system and choose one safe improvement that reduces friction now, teaches the team something useful, and lowers the next cost of change without depending on a parallel platform.
 
 ## What to watch
 
-- whether the team is gaining confidence
-- whether decisions are becoming clearer
-- whether the improvement is real in production terms
-- whether the work is reducing future dependence rather than hiding it
+Watch whether the team is gaining confidence, whether decisions are getting clearer, whether improvement is real in production terms, and whether dependence is falling rather than being hidden.
 
 ## What success looks like
 

--- a/cases/platform-seams.mdx
+++ b/cases/platform-seams.mdx
@@ -1,6 +1,6 @@
 ---
 title: Platform seams
-description: A case pattern where the real slowdown lives between teams rather than inside one team’s code.
+description: A case pattern where the real slowdown lives between teams rather than inside one team's code.
 ---
 
 Many delivery problems are described as team problems when they are really seam problems.
@@ -9,37 +9,19 @@ A product team may appear slow, blocked, or inconsistent, but the real friction 
 
 ## The real constraint
 
-The issue is often one or more of these:
-
-- unclear service boundaries
-- weak interface definitions
-- approval paths that no longer match reality
-- dependency on teams with different incentives
-- work that crosses ownership lines without shared language
+The real constraint is usually an unresolved interface: unclear service boundaries, weak definitions, mismatched approval paths, and dependencies crossing ownership lines without shared language.
 
 ## The wrong move
 
-The wrong move is to focus only on the local team’s execution.
-
-That usually creates pressure without actually reducing the bottleneck.
+The wrong move is to focus only on the local team's execution. That often increases pressure on one team while leaving the cross-team bottleneck intact and mislabeled as local underperformance.
 
 ## The grounded move
 
-Treat the seam as part of the work.
-
-That means:
-
-- making the dependency visible
-- naming the ownership boundary clearly
-- bringing the neighboring team into the real problem
-- improving the interface, not just the local behavior
+Treat the seam as part of the work by making dependency visible, naming ownership boundaries clearly, involving neighboring teams in the real constraint, and improving the interface instead of only local behavior.
 
 ## What to watch
 
-- whether the teams describe the seam differently
-- whether “not supported” is standing in for “not yet clarified”
-- whether approval exists without clear accountability
-- whether the local team is being blamed for a cross-team design problem
+Watch for teams describing the seam differently, "not supported" standing in for "not yet clarified," approval without accountability, and local blame for what is fundamentally a cross-team design problem.
 
 ## What success looks like
 

--- a/cases/vendor-friction.mdx
+++ b/cases/vendor-friction.mdx
@@ -9,45 +9,19 @@ The software exists. The delivery path exists. The handoffs exist. But the clien
 
 ## The real constraint
 
-The issue is often not only the vendor product.
-
-It is the combination of:
-
-- black-box assumptions
-- weak visibility into how things actually work
-- blurred boundaries between vendor responsibility and client ownership
-- client dependence on specialist knowledge that never really transfers
+The issue is usually not only the vendor product. It is often a mix of contract boundaries and learned client dependency, where critical knowledge stays external and routine changes require mediation.
 
 ## The wrong move
 
-The wrong move is to accept the vendor operating model as fixed truth.
-
-That tends to produce:
-
-- quiet dependency
-- fragile delivery rituals
-- low client confidence
-- stalled modernization because every change feels mediated
+The wrong move is to accept the vendor operating model as fixed truth. That tends to normalize quiet dependency, reduce client confidence, and stall modernization because every change feels externally gated.
 
 ## The grounded move
 
-Clarify the seams.
-
-Work out:
-
-- what the vendor truly owns
-- what the client should own
-- where the current model creates avoidable dependence
-- what can be made more visible, predictable, and client-operable
-
-Then make one small move that improves client understanding or control without triggering unnecessary confrontation.
+Clarify what the vendor truly owns, what the client should own, and where the current model creates avoidable dependence. Then make one small move that improves client understanding or control without triggering unnecessary confrontation.
 
 ## What to watch
 
-- whether knowledge is staying with the client team
-- whether workflows are becoming more predictable
-- whether vendor constraints are real or simply inherited
-- whether the client can explain the system in its own words
+Watch whether knowledge is staying with the client team, whether workflows are becoming predictable, whether constraints are real or inherited assumptions, and whether the client can explain the system in its own words.
 
 ## What success looks like
 

--- a/customers/index.mdx
+++ b/customers/index.mdx
@@ -3,17 +3,36 @@ title: For Customers
 description: What Grounded Systems helps with, how the model works, and when it is a good fit.
 ---
 
-<div className="gs-hub-page" />
+Grounded Systems fits organizations that need real progress in systems they already rely on. We work inside the current environment with the people who own the outcome, so modernization becomes safer, clearer, and easier to carry forward.
 
-Grounded Systems is for organizations that need progress in systems they already rely on.
+## Where we help most
 
-<p className="gs-lead">
-  This work fits best when modernization matters, but replacing everything, outsourcing the hard parts, or running a big parallel program would add more risk than clarity.
-</p>
+We are most useful when teams are dealing with problems like these:
+
+- delivery is slower or more fragile than it should be
+- the system is hard to change safely
+- ownership is split across teams or hidden behind process
+- important decisions keep getting pushed outward instead of made close to the work
+- modernization is necessary, but a clean restart is unrealistic
+
+## How the work works
+
+We embed as a small senior unit inside the real environment.
+
+That means we work with the team that owns the system, use the current tools and constraints as the starting point, and help create small but meaningful improvements that the team can keep carrying after we leave.
+
+The goal is not to become your delivery engine. The goal is to help your own teams become more capable, more confident, and more able to move without outside dependence.
+
+## What good clients should expect
+
+- practical movement inside the current system
+- clear reasoning and visible trade-offs
+- shared work rather than outside substitution
+- growing confidence and judgment in the host team
+- an exit path designed into the engagement
 
 ## Start with the right path
 
-<div className="gs-overview-band">
 <CardGroup cols={2}>
   <Card title="What we help with" icon="target" href="/customers/what-we-help-with" cta="See focus areas" arrow>
     See the kinds of delivery, ownership, and modernization problems this model is built to address.
@@ -25,29 +44,9 @@ Grounded Systems is for organizations that need progress in systems they already
     Use the fit guidance to assess readiness, boundaries, and whether the conditions are right.
   </Card>
 </CardGroup>
-</div>
 
-## Common fit signals
+## When this is a strong fit
 
-<div className="gs-signal-grid gs-signal-grid-2">
-  <div className="gs-signal-card">
-    <Icon icon="gauge" />
-    <h3>Delivery drag is rising</h3>
-    <p>Delivery is slower or more fragile than it should be.</p>
-  </div>
-  <div className="gs-signal-card">
-    <Icon icon="split" />
-    <h3>Ownership seams are unclear</h3>
-    <p>Ownership is split across teams or hidden behind process.</p>
-  </div>
-  <div className="gs-signal-card">
-    <Icon icon="move-right" />
-    <h3>Decisions keep moving outward</h3>
-    <p>Important calls are pushed away from the people closest to the work.</p>
-  </div>
-  <div className="gs-signal-card">
-    <Icon icon="refresh-cw" />
-    <h3>Modernization is needed in place</h3>
-    <p>A clean restart is unrealistic, but standing still is not an option.</p>
-  </div>
-</div>
+This model works best when leadership wants stronger internal capability, not just more external throughput.
+
+It also works best when the host team can own backlog, decisions, delivery, and operations while we are present. If those conditions are not there yet, the first step is usually to create them.

--- a/index.mdx
+++ b/index.mdx
@@ -3,17 +3,16 @@ title: Grounded Systems
 description: Modernize from within, with a small senior team that helps yours make real progress without giving up ownership.
 ---
 
-<div className="gs-hub-page" />
+Grounded Systems helps organizations modernize from within by working inside the systems they already rely on, with the people who already own them. The point is not more outside activity. It is safer change, clearer ownership, and a team that is more capable after we leave.
 
-Grounded Systems helps organizations modernize from within.
+## What this looks like
 
-<p className="gs-lead">
-  We work inside the real system, with the people who already own it, so change becomes safer, clearer, and easier to carry forward.
-</p>
+Modernization usually stalls for a reason. The system is active, the constraints are real, and the team still has to run the business while change is happening.
+
+Grounded Systems is a small senior consulting capability that embeds where work is stuck and helps teams make practical progress in place. We do not build a separate track of change around the customer. We work with the existing team, inside the existing environment, and design the work so outside presence tapers over time.
 
 ## Start where you fit
 
-<div className="gs-overview-band">
 <CardGroup cols={2}>
   <Card title="For customers" icon="building-2" href="/customers/index" cta="See customer fit" arrow>
     Understand where this model fits, how the work behaves, and what good clients should expect.
@@ -34,24 +33,13 @@ Grounded Systems helps organizations modernize from within.
     Use the glossary, FAQ, and contribution guidance when you need stable definitions and direct answers.
   </Card>
 </CardGroup>
-</div>
 
-## What changes when this works
+## What we help make possible
 
-<div className="gs-signal-grid">
-  <div className="gs-signal-card">
-    <Icon icon="shield-check" />
-    <h3>Safer change</h3>
-    <p>Make progress inside the live system without pretending risk disappears.</p>
-  </div>
-  <div className="gs-signal-card">
-    <Icon icon="key-round" />
-    <h3>Clearer ownership</h3>
-    <p>Keep decisions and delivery close to the people who live with the result.</p>
-  </div>
-  <div className="gs-signal-card">
-    <Icon icon="link-2-off" />
-    <h3>Less outside dependence</h3>
-    <p>Leave the team more able to continue after we leave.</p>
-  </div>
-</div>
+This work helps teams make safer progress in systems that already carry real value. It brings ownership closer to the work, improves technical and organizational judgment, and reduces the need for outside delivery over time. The aim is not a burst of activity while we are present. It is modernization that still holds after we leave.
+
+## Why this model feels different
+
+Many modernization efforts create movement first and capability later, if it arrives at all. A new platform appears. A parallel system gets built. Another team ships the change. The customer is still left depending on someone else to keep it moving.
+
+Grounded Systems works the other way around. We help teams learn while shipping, keep trade-offs visible, and strengthen the habits that let them continue on their own.

--- a/playbook/decision-patterns.mdx
+++ b/playbook/decision-patterns.mdx
@@ -22,12 +22,7 @@ Useful prompts:
 
 When the environment is uncertain, a reversible move teaches faster than a heavy solution. Favor steps that create evidence quickly without locking the organization into high-cost commitments.
 
-A good move is often one that is:
-
-- safe to try
-- cheap to reverse
-- small enough to learn from quickly
-- still useful even if it is not the final answer
+Good early moves are safe to try, cheap to reverse, small enough to learn from quickly, and still useful even if they are not the final answer.
 
 ## Simplify before you add
 
@@ -49,17 +44,13 @@ If ownership is unclear, pause the tooling decision.
 
 Cross-team seams are part of the system, not side context. A decision that looks correct inside one team can fail quickly if the seam is unresolved.
 
-Check early whether the bottleneck is between teams, whether words mean the same thing on both sides, and whether "not supported" is hiding an unworked interface.
+Check early whether the bottleneck is between teams, whether words mean the same thing on both sides, and whether "not supported" is hiding an unworked interface. Many teams are blamed for delay when the real issue is an unresolved interface with another group.
 
 ## Use early progress to prove something real
 
 Early wins matter when they prove that the client team can move from inside the current system. The point is traction that teaches, not visible motion that impresses.
 
-A useful first move should show that:
-
-- the client team is participating directly
-- dependency can be reduced in practice
-- the next move is now easier than before
+A useful first move should directly show customer participation, practical dependence reduction, and a clearer next step than before.
 
 ## Useful default questions
 

--- a/playbook/entry-gate.mdx
+++ b/playbook/entry-gate.mdx
@@ -13,44 +13,40 @@ Starting under the wrong conditions usually creates confusion, weak ownership, o
 
 The team must own backlog, delivery decisions, and operations, or be very close to doing so.
 
-Without this, capability cannot take root where it needs to live.
+If this is missing, capability cannot take root where it needs to live and the work drifts into outside substitution.
 
 ### 2. The sponsor wants capability, not just throughput
 
 If the real ask is external speed or external rescue, the model will be distorted quickly.
 
-The sponsor must understand that stronger internal capability is the main outcome.
+The sponsor has to value stronger internal judgment and ownership as the main outcome, not as a side benefit.
 
 ### 3. The team has room to participate
 
 This model depends on pairing, learning, and visible involvement.
 
-If the team has no time, no attention, or no access to the work, the engagement becomes performance.
+If the team has no time, no attention, or no access to the work, the engagement becomes performative and transfer never happens.
 
 ### 4. No hard blocker makes autonomy impossible
 
-Some environments are blocked by structure rather than effort.
+Some situations fail not because the team is weak, but because the structure makes ownership impossible.
 
-Examples:
-- platform gatekeeping with no room to negotiate
-- vendor lock-in that prevents meaningful client ownership
-- decision structures that keep the host team permanently dependent
+Typical blockers include platform gatekeeping with no room to negotiate, vendor lock-in that prevents meaningful client ownership, or decision structures that keep the host team permanently dependent.
 
 ## Questions to ask early
 
 - Who actually owns the backlog?
 - Who can approve technical direction?
 - Who operates the system when things go wrong?
-- What would the sponsor call “success” after three months?
+- What would the sponsor call "success" after three months?
 - What would still depend on us if the engagement ended abruptly?
 
 ## Red flags
 
-- “We mainly need experienced hands to move faster”
-- “The team is too busy to be involved deeply”
-- “Ownership is still a bit unclear”
-- “We’ll figure out taper later”
-- “The tool choice is already made”
+- "We mainly need experienced hands to move faster"
+- "The team is too busy to be involved deeply"
+- "Ownership is still a bit unclear"
+- "We'll figure out taper later"
 
 ## Decision rule
 

--- a/playbook/field-signals.mdx
+++ b/playbook/field-signals.mdx
@@ -9,50 +9,24 @@ They matter because systems reveal themselves through behavior first: who waits,
 
 ## Ownership signals
 
-Ownership is visible in who can move work without escalation and who can explain trade-offs in plain language. Weak ownership often hides behind polite coordination.
-
-Watch for:
-
-- who makes decisions without escalation
-- who people wait for when work stalls
-- whether operational accountability is clear at 02:00
+Ownership is visible in who can move work without escalation and who can explain trade-offs in plain language. Weak ownership often hides behind polite coordination, with progress pausing until one specific person validates routine choices.
 
 ## Misalignment signals
 
-Misalignment usually appears as smooth language with inconsistent behavior underneath. People may agree publicly while carrying different definitions privately.
-
-Watch for:
-
-- repeated terms used with different meanings
-- silence when responsibility is named
-- energy drops around certain handoffs
+Misalignment usually appears as smooth language with inconsistent behavior underneath. People may agree publicly while carrying different definitions privately, and friction concentrates at handoffs where meaning diverges.
 
 ## Dependency signals
 
-Dependency is often visible before anyone names it. The pattern is that movement depends on specialist mediation instead of routine team capability.
-
-Watch for:
-
-- "only X knows that"
-- sharp slowdown when one outside actor is unavailable
-- work that cannot proceed without external interpretation
+Dependency is often visible before anyone names it. Movement depends on specialist mediation instead of routine team capability, and work slows sharply when one outside actor is unavailable.
 
 ## Tool-first signals
 
-Tool-first thinking appears when solution shape outruns understanding of the current system. This often increases load before it reduces friction.
-
-Watch for:
-
-- platform choices proposed before constraints are clear
-- ownership questions deferred until after tooling decisions
-- low curiosity about current workflows and boundaries
+Tool-first thinking appears when solution shape outruns understanding of the current system. Platform decisions land early while ownership and constraint questions are deferred, which increases load before it reduces friction.
 
 ## Capability-growth signals
 
-Genuine growth shows up when the client team is carrying more judgment directly, not only producing more output.
+Genuine growth shows up when the client team is carrying more judgment directly, not only producing more output. You can hear this when trade-offs are explained in their own language and seam work is handled without outside prompting.
 
-Watch for:
+## Signals are clues, not conclusions
 
-- trade-offs explained in the client team's own words
-- seam conversations handled directly across teams
-- simplification choices made without outside prompting
+Signals help practitioners ask better questions. They are not permission to jump to diagnosis without context.

--- a/playbook/index.mdx
+++ b/playbook/index.mdx
@@ -3,17 +3,27 @@ title: Playbook
 description: Practical guidance for entering, navigating, and exiting real modernization work without losing the plot.
 ---
 
-<div className="gs-hub-page" />
+The playbook turns the stance into practical moves for real environments. It helps you decide when to enter, what to notice, and how to move without creating new dependency.
 
-The playbook turns the stance into practical moves.
+## What you will find here
 
-<p className="gs-lead">
-  It is not a fixed method and it is not a bag of rituals. It is a working guide for entering real environments, reading what is happening, and making decisions that help the customer move without creating new dependency.
-</p>
+- entry gate checks
+- discovery guidance for reading the real system
+- decision patterns for choosing safe, useful moves
+- field signals that show where friction and drift are hiding
+- sponsor behavior
+- ways of working in the open
+- taper and exit
+- lightweight checklists to support judgment
+
+## How to use it
+
+Use this section to support decisions in context.
+
+The goal is not to copy visible practices from page to page. The goal is to make better calls inside the real system, with the real team, under real constraints.
 
 ## Start with the right move
 
-<div className="gs-overview-band">
 <CardGroup cols={2}>
   <Card title="Entry gate" icon="door-open" href="/playbook/entry-gate" cta="Run entry checks" arrow>
     Use the entry checks to decide whether the work should begin at all.
@@ -34,29 +44,11 @@ The playbook turns the stance into practical moves.
     Keep the engagement moving toward lower dependence instead of permanent presence.
   </Card>
 </CardGroup>
-</div>
 
-## Route through the playbook
+## The anchor question
 
-<div className="gs-signal-grid gs-signal-grid-2">
-  <div className="gs-signal-card">
-    <Icon icon="door-open" />
-    <h3>Entry gate</h3>
-    <p>Check if the work should begin now and under what boundaries.</p>
-  </div>
-  <div className="gs-signal-card">
-    <Icon icon="search" />
-    <h3>Discovery</h3>
-    <p>Read the real system before prescribing solutions or tooling changes.</p>
-  </div>
-  <div className="gs-signal-card">
-    <Icon icon="git-branch" />
-    <h3>Decision patterns</h3>
-    <p>Pick moves that are safer, clearer, and easier for the customer to own.</p>
-  </div>
-  <div className="gs-signal-card">
-    <Icon icon="hourglass" />
-    <h3>Taper and exit</h3>
-    <p>Keep outside presence temporary and capability growth explicit.</p>
-  </div>
-</div>
+When in doubt, ask:
+
+**Will this leave the customer more able to continue after we leave?**
+
+If the answer is no, the move is probably wrong, premature, or too heavy.

--- a/playbook/taper-and-exit.mdx
+++ b/playbook/taper-and-exit.mdx
@@ -9,40 +9,25 @@ If the work only functions while we are present, then the work has not really tr
 
 ## The normal shift
 
-The motion should look roughly like this:
-
-- doing
-- pairing
-- reviewing
-- advising
-- leaving
-
-The sequence is simple, but the timing is contextual.
+The motion should usually move from doing, to pairing, to reviewing, to advising, to leaving. The sequence is simple, but timing is contextual and should follow real capability growth.
 
 ## What taper should feel like
 
 The client team should gradually become the clear center of gravity.
 
-That means:
-
-- they make more decisions directly
-- they run more of the work without support
-- they handle more seams with neighboring groups
-- they explain the reasoning behind changes themselves
+That means they make more decisions directly, run more of the work without support, handle more seams with neighboring groups, and explain the reasoning behind changes themselves.
 
 ## Signs taper is too early
 
-- work pauses when we step back
-- edge cases still trigger dependence
-- the sponsor still treats us as essential
-- the team asks for direction more than challenge
+These signs matter because they show transfer has not become stable yet.
+
+Work pauses when we step back, edge cases still trigger dependence, sponsors still treat us as essential, and the team asks for direction more than challenge.
 
 ## Signs taper is working
 
-- the team continues without prompting
-- trade-offs are articulated clearly
-- blockers are addressed directly by the client team
-- new work follows the same logic without us inserting it
+These signs matter because they show capability is becoming durable in the host team.
+
+The team continues without prompting, trade-offs are articulated clearly, blockers are addressed directly by the client team, and new work follows the same logic without us inserting it.
 
 ## Exit notes should cover
 
@@ -54,13 +39,7 @@ That means:
 
 ## Return is allowed
 
-A short re-entry is not failure.
-
-Return is useful when:
-- a new blocker appears
-- leadership changes disrupt the pattern
-- a seam becomes newly active
-- the team needs a brief reset, not a renewed dependency
+A short re-entry is not failure. It is disciplined re-entry when a new blocker appears, leadership change disrupts the pattern, or an interface becomes newly active.
 
 The key is to re-enter briefly, unblock, and step back again.
 

--- a/playbook/working-in-the-open.mdx
+++ b/playbook/working-in-the-open.mdx
@@ -13,55 +13,23 @@ It is a practical way to reduce confusion, surface trade-offs, and strengthen ow
 
 Hidden work creates fragile systems.
 
-When decisions, blockers, and reasoning stay trapped inside private channels or individual heads, teams lose context, neighboring groups guess, and dependency grows quietly.
-
-Open work makes it easier to:
-
-- align without excessive meetings
-- expose seams early
-- make trade-offs visible
-- reduce single-person dependency
-- help the client team carry the work after we leave
+When decisions, blockers, and reasoning stay trapped inside private channels or individual heads, teams lose context, neighboring groups guess, and dependency grows quietly. Open work makes alignment easier without excess meetings, exposes seams earlier, and helps reduce single-person dependency.
 
 ## What should be visible
 
 The goal is not maximum exposure. The goal is useful visibility.
 
-Useful things to make visible include:
-
-- what is being changed
-- why it is being changed
-- what constraint or friction is being addressed
-- what trade-offs were considered
-- what remains unresolved
-- who owns the next move
+Useful visibility includes what is changing, why it is changing, what friction is being addressed, which trade-offs were considered, what remains unresolved, and who owns the next move.
 
 ## Where visibility should live
 
 Put visibility as close to the work as possible.
 
-Prefer:
-
-- pull requests
-- issues
-- architectural notes
-- decision records
-- plain-language docs
-- shared boards where real work moves
-
-Use chat for coordination, not as the final resting place of important reasoning.
+Prefer pull requests, issues, architectural notes, decision records, plain-language docs, and shared boards where work actually moves. Chat helps coordination in the moment, but it does not leave durable context near the work.
 
 ## What good open work looks like
 
-Open work usually has these qualities:
-
-- simple language
-- visible intent
-- clear ownership
-- enough context for others to follow
-- no decorative documentation for its own sake
-
-A short clear note is better than a polished document nobody uses.
+Good open work uses simple language, visible intent, clear ownership, and enough context for others to follow. It avoids decorative documentation for its own sake, because a short clear note near the work is more useful than polished artifacts no one uses.
 
 ## What this is not
 
@@ -94,14 +62,7 @@ Things are visible, but no one is clearly carrying the next move.
 
 ## Practical habits
 
-Useful habits include:
-
-- explain trade-offs in pull requests
-- write short notes where decisions happen
-- name blockers plainly
-- show what is still uncertain
-- make ownership explicit
-- invite neighboring teams into seam problems early
+Useful habits are simple: explain trade-offs in pull requests, write short notes where decisions happen, name blockers plainly, show what is still uncertain, make ownership explicit, and invite neighboring teams into seam problems early.
 
 ## Why this matters in this model
 

--- a/practitioners/how-we-think.mdx
+++ b/practitioners/how-we-think.mdx
@@ -9,29 +9,23 @@ We start by trying to understand the actual shape of the problem, the real owner
 
 ## We think in systems
 
-That means we look at:
-
-- how work moves
-- where decisions live
-- what dependencies keep repeating
-- how people experience the system
-- what becomes fragile under pressure
+We follow how work moves, where decisions really live, what fails under pressure, and how the environment feels to the people inside it.
 
 ## We think in trade-offs
 
 We do not assume every improvement should maximize speed.
 
-We care more about moves that increase clarity, reduce fragility, and lower the future cost of change.
+We care more about moves that increase clarity, reduce fragility, and lower the future cost of change. Speed matters, but speed without clarity often pushes cost and fragility downstream.
 
 ## We think from inside the real environment
 
 We distrust solutions that only work on slides.
 
-The real test is whether something makes sense inside the existing system, under current constraints, with the people who actually have to carry it.
+The real test is whether something makes sense inside the existing system, under current constraints, with the people who actually have to carry it. Slide-friendly solutions usually fail because they bypass constraints the team still has to live with later.
 
 ## We think capability first
 
-A useful move is not only one that solves today’s problem.
+A useful move is not only one that solves today's problem.
 
 It is one that leaves the client team more able to understand, operate, and evolve the system afterward.
 

--- a/practitioners/index.mdx
+++ b/practitioners/index.mdx
@@ -3,17 +3,27 @@ title: For Practitioners
 description: What this work asks of the people doing it, and who tends to thrive in it.
 ---
 
-<div className="gs-hub-page" />
+This work fits practitioners who can enter a real environment, read what is actually happening, and help teams move without taking over. It rewards judgment, restraint, and the ability to make other people stronger in the work.
 
-This work is for practitioners who can enter a real environment, understand what is actually happening, and help a team move without taking over.
+## The kind of practitioner who tends to fit
 
-<p className="gs-lead">
-  It suits people who care about systems, judgment, and the quiet work of making others more capable.
-</p>
+People who thrive here are usually:
+
+- calm in messy environments
+- curious before certain
+- practical in both language and action
+- able to teach while doing
+- comfortable working across technical and organizational seams
+- willing to challenge assumptions without making themselves the center of gravity
+
+## What the work asks of you
+
+This is not just technical execution.
+
+It asks for timing, restraint, pattern recognition, and the ability to help teams grow stronger while still making real progress. You have to read the system in front of you, notice where friction actually lives, and choose moves the customer can own at 02:00, not just in a presentation.
 
 ## Explore the practitioner path
 
-<div className="gs-overview-band">
 <CardGroup cols={2}>
   <Card title="Who thrives here" icon="user-round-check" href="/practitioners/who-thrives-here" cta="See the profile" arrow>
     Get more specific about the traits and operating habits that make this work sustainable.
@@ -25,29 +35,7 @@ This work is for practitioners who can enter a real environment, understand what
     Read the practical bar for judgment, restraint, and delivery integrity in the field.
   </Card>
 </CardGroup>
-</div>
 
-## What good looks like
+## Why this matters
 
-<div className="gs-signal-grid gs-signal-grid-2">
-  <div className="gs-signal-card">
-    <Icon icon="waveform" />
-    <h3>Calm under pressure</h3>
-    <p>Stay steady in messy environments where constraints are real and changing.</p>
-  </div>
-  <div className="gs-signal-card">
-    <Icon icon="search-check" />
-    <h3>Curious before certain</h3>
-    <p>Read what the system is doing before jumping to preferred answers.</p>
-  </div>
-  <div className="gs-signal-card">
-    <Icon icon="users-round" />
-    <h3>Teach while delivering</h3>
-    <p>Help teams build capability while making practical progress together.</p>
-  </div>
-  <div className="gs-signal-card">
-    <Icon icon="shield-alert" />
-    <h3>Challenge without theater</h3>
-    <p>Raise the bar directly without turning yourself into the center of gravity.</p>
-  </div>
-</div>
+Grounded Systems is meant to be a small senior capability with a clear identity. That only works if the people doing the work value clarity, ownership, low politics, and delivery integrity more than status or control.

--- a/practitioners/who-thrives-here.mdx
+++ b/practitioners/who-thrives-here.mdx
@@ -7,31 +7,16 @@ This work suits people who can operate without hiding behind certainty.
 
 It tends to fit practitioners who can enter complexity, stay calm, and help others move without becoming the center of gravity.
 
-## People who usually fit well
+## Steady in ambiguity
 
-They tend to be:
+Steady in ambiguity means they do not need artificial certainty before they can help. They can enter a messy environment, separate signal from noise, and keep other people calm while the real constraint becomes clearer.
 
-- steady under ambiguity
-- practical in how they think
-- curious before they prescribe
-- willing to challenge assumptions
-- able to work across system and team boundaries
-- comfortable sharing credit
-- more interested in coherence than performance
+## Curious before prescribing
 
-## How they usually operate
+Curious before prescribing means they ask questions that improve the shape of the work before they suggest tools or frameworks. They are trying to understand the system, not prove that they already have the answer.
 
-They often:
+## Low-ego influence
 
-- observe before they push
-- ask clarifying questions that change the conversation
-- notice weak signals early
-- simplify what others are making heavy
-- help teams gain confidence rather than dependence
-- make progress without needing spotlight
+Low-ego influence means they can move an environment without becoming its center of gravity. They share credit, explain trade-offs plainly, and leave teams more confident in their own judgment.
 
-## Why this matters
-
-This team is not built around heroics.
-
-It is built around judgment, trust, and the ability to make complex environments more workable for the people who stay.
+This work is not built around heroics, charisma, or expert theater. It depends on judgment people can trust under pressure.

--- a/principles/anti-patterns.mdx
+++ b/principles/anti-patterns.mdx
@@ -9,84 +9,28 @@ Most traps promise speed, certainty, or cleanliness up front. The long-term cost
 
 ## Feature factory drift
 
-This trap appears when outside contributors become valued mainly for output volume and the client team quietly shifts from owner to requester.
-
-It is attractive because visible throughput creates quick confidence for sponsors.
-
-Watch for:
-
-- outside contributors treated as the delivery center
-- client participation thinning out over time
-- success measured only in shipped volume
-
-The cost is simple: movement increases, but client capability does not.
+This trap appears when outside contributors become valued mainly for output volume and the client team quietly shifts from owner to requester. It often starts with good intent and quick visible delivery, then participation from the customer team thins as outside actors become the default delivery center. What it costs: movement increases, but client capability does not.
 
 ## Modernize elsewhere, migrate later
 
-This trap appears when teams build a cleaner parallel world first and postpone integration with the live system.
-
-It is attractive because it feels technically cleaner and easier to narrate.
-
-Watch for:
-
-- future-state architecture dominating current-state work
-- thin links to operational constraints
-- migration complexity deferred as a later problem
-
-The cost is a second problem space before the first one is improved.
+This trap appears when teams build a cleaner parallel world first and postpone integration with the live system. It usually starts as a clarity play, then current constraints and migration complexity get deferred until they become the main problem. What it costs: a second problem space before the first one is improved.
 
 ## Premature tooling
 
-This trap appears when tools become the center of the plan before ownership and constraints are grounded.
-
-It is attractive because tools provide fast structure and visible direction.
-
-Watch for:
-
-- tooling decisions ahead of ownership decisions
-- low attention to existing system behavior
-- context questions postponed until implementation
-
-The cost is inherited complexity without relief on the real bottleneck.
+This trap appears when tools become the center of the plan before ownership and constraints are grounded. It often starts with platform enthusiasm, while context and responsibility questions are postponed until implementation. What it costs: inherited complexity without relief on the real bottleneck.
 
 ## No-exit consulting
 
-This trap appears when there is no credible taper path and outside presence remains structurally central.
-
-It is attractive because continuous support feels safer than designing independence.
-
-Watch for:
-
-- routines pause when outside actors step back
-- taper repeatedly delayed without a clear reason
-- client teams waiting for outside judgment on routine calls
-
-The cost is dependency becoming the product.
+This trap appears when there is no credible taper path and outside presence remains structurally central. It usually starts as risk management, then routines begin to pause whenever outside contributors step back. What it costs: dependency becoming the product.
 
 ## Local success sold as systemic change
 
-This trap appears when one strong local win is used as proof that the wider organization has transformed.
-
-It is attractive because success stories are easier than replication work.
-
-Watch for:
-
-- broad claims supported by one team example
-- no evidence of repeatable conditions elsewhere
-- narrative scale greater than operational scale
-
-The cost is false confidence masking unresolved system constraints.
+This trap appears when one strong local win is used as proof that the wider organization has transformed. It often starts with a real success story, but replication conditions remain unclear and constraints elsewhere stay untouched. What it costs: false confidence masking unresolved system constraints.
 
 ## Ritual imitation without ownership
 
-This trap appears when teams copy visible practices but do not internalize the reasoning behind them.
+This trap appears when teams copy visible practices but do not internalize the reasoning behind them. It usually starts with energetic adoption of ceremonies and language, then reverts under pressure because judgment was never transferred. What it costs: a process-shaped shell with no durable capability inside it.
 
-It is attractive because visible form is faster to copy than judgment.
+## Why these traps keep winning
 
-Watch for:
-
-- ceremonies retained while trade-offs stay implicit
-- language copied without behavioral change
-- quick reversion under pressure
-
-The cost is a process-shaped shell with no durable capability inside it.
+These traps keep winning because they offer speed, certainty, or clean narratives at the start. The hidden trade is that ownership moves outward and the hard learning the organization still needs gets delayed.

--- a/principles/grounded-practitioners.mdx
+++ b/principles/grounded-practitioners.mdx
@@ -3,51 +3,24 @@ title: Grounded practitioners
 description: The kind of practitioner this model depends on.
 ---
 
-This model depends on people with more than technical ability.
+This page is about role responsibility, not personality style. Grounded practitioners protect the stance in daily decisions, especially when pressure pushes teams toward speed theater or dependency.
 
-It depends on people who can carry ambiguity, read systems, and help others become stronger without taking over.
+## What this role protects
 
-## Core traits
+This role protects customer ownership, practical clarity, and decisions that still make sense in the real system. It keeps the work tied to capability growth, not just external throughput.
 
-Grounded practitioners tend to be:
+## What grounded practitioners notice early
 
-- calm under uncertainty
-- curious before certain
-- strong in judgment, not just execution
-- willing to challenge gently but clearly
-- able to simplify without becoming simplistic
-- comfortable working across technical and organizational boundaries
+They notice weak ownership seams, repeated bottlenecks, and moments where language sounds aligned but behavior is not. They can see when a local problem is really a cross-team interface issue.
 
-## What they do well
+## What they refuse to normalize
 
-They can:
+They refuse to normalize tool-first planning, hidden reasoning, permanent outside centrality, and local wins being sold as systemic change. They push for plain trade-offs and customer-operable outcomes.
 
-- read weak signals early
-- see where ownership is real and where it is performed
-- help teams move without becoming the center of gravity
-- surface trade-offs in plain language
-- resist the urge to decorate the work with excess structure
+## Why this role is hard to fake
 
-## What they avoid
-
-They do not:
-
-- hide behind frameworks
-- turn tools into ideology
-- equate speed with value
-- confuse visibility with contribution
-- optimize for individual heroics
-
-## Why this matters
-
-This model fails when staffed with people who are technically strong but posture-weak.
-
-A person can be excellent at building systems and still be the wrong fit for embedded capability work.
+This role is hard to fake because it shows up under pressure. It requires calm judgment, low-ego influence, and the discipline to keep work reversible and owned by the team that must carry it.
 
 ## Litmus test
 
-A useful question is:
-
-Can this person hold the line under pressure while keeping trust intact?
-
-If not, they may contribute, but they should not anchor the work.
+Ask: does this practitioner leave the team more capable and more confident to continue without them?

--- a/principles/index.mdx
+++ b/principles/index.mdx
@@ -3,17 +3,20 @@ title: Principles
 description: The principles that shape how Grounded Systems makes decisions and avoids drift.
 ---
 
-<div className="gs-hub-page" />
+These principles keep the work honest when pressure rises. They protect customer ownership, keep modernization tied to the real system, and reduce the chance that good intent turns into dependence.
 
-These principles exist to keep the work clear when pressure rises.
+## The principles
 
-<p className="gs-lead">
-  They are not slogans. They are practical constraints that protect customer ownership, keep modernization grounded in the real system, and reduce the chance that good intent turns into dependency.
-</p>
+- **Customer ownership comes first.** Client teams own backlog, decisions, delivery, and operations from day one.
+- **Modernize in place.** Start where the value already lives instead of defaulting to parallel replacement.
+- **Capability matters more than output volume.** Progress only counts if the customer becomes more able to continue without us.
+- **Tools follow context.** Tooling choices should lower friction and be clearly owned, not act as transformation theater.
+- **Simplicity and reversibility first.** Prefer moves that are easier to explain, easier to operate, and cheaper to undo.
+- **Work in the open.** Keep reasoning, trade-offs, and ownership visible near the work.
+- **Design exit into the model.** If success depends on permanent outside presence, the engagement has drifted.
 
 ## Explore the principle set
 
-<div className="gs-overview-band">
 <CardGroup cols={2}>
   <Card title="Core principles" icon="badge-check" href="/principles/core-principles" cta="See the full set" arrow>
     Read the full stance in a tighter summary of what Grounded Systems protects and why.
@@ -28,12 +31,9 @@ These principles exist to keep the work clear when pressure rises.
     Connect the principles to the expectations placed on the people doing the work.
   </Card>
 </CardGroup>
-</div>
 
-## What these principles protect
+## Why these principles matter
 
-<div className="gs-chip-row" role="list" aria-label="Principle outcomes">
-  <span role="listitem">Ownership</span>
-  <span role="listitem">Simplicity</span>
-  <span role="listitem">Exit</span>
-</div>
+A lot of modernization effort fails for the same reason: it creates visible movement without leaving behind judgment, confidence, or durable ownership.
+
+These principles exist to prevent that failure mode.

--- a/reference/contribution-model.mdx
+++ b/reference/contribution-model.mdx
@@ -7,6 +7,8 @@ This site should not grow by accumulation alone.
 
 It should grow in a way that keeps the structure clear, the voice coherent, and the ideas grounded in real work.
 
+This site is meant to stay useful under growth. That means adding material with intent, not just adding more material. A good contribution makes the model easier to understand, easier to apply, or easier to trust.
+
 ## What belongs here
 
 Useful additions tend to do one of four things:
@@ -28,22 +30,11 @@ Avoid adding material that is:
 
 ## Writing rules
 
-Write in plain language.
-
-Prefer:
-- simple words
-- short sections
-- direct statements
-- concrete nouns and verbs
-- visible trade-offs
-
-Avoid:
-- inflated tone
-- borrowed jargon
-- performance language
-- unnecessary abstraction
+Write in plain language. Prefer simple words, short sections, direct statements, concrete nouns and verbs, and visible trade-offs. Avoid inflated tone, borrowed jargon, performance language, and unnecessary abstraction.
 
 ## Structural rules
+
+Page role matters because readers come here with different jobs to do: understanding the model, applying it, seeing it in practice, or checking a stable definition.
 
 When adding a page, decide first what role it plays:
 

--- a/reference/index.mdx
+++ b/reference/index.mdx
@@ -3,17 +3,16 @@ title: Reference
 description: Stable definitions, direct answers, and guidance that keeps the site coherent over time.
 ---
 
-<div className="gs-hub-page" />
+The reference section holds the stable material that keeps the rest of the site clear. Use it when you need a precise definition, a direct answer, or guidance on how the documentation should grow without losing its shape.
 
-The reference section holds the stable material that supports the rest of the site.
+## What belongs here
 
-<p className="gs-lead">
-  Use it when you need a precise definition, a direct answer, or guidance on how the documentation should evolve without losing its shape.
-</p>
+- glossary terms that keep the language clear and consistent
+- common questions with short, direct answers
+- contribution guidance for growing the site without drifting into noise
 
 ## Start here
 
-<div className="gs-overview-band">
 <CardGroup cols={3}>
   <Card title="Glossary" icon="book-a" href="/reference/glossary" cta="Open glossary" arrow>
     Use the stable definitions that keep the language precise across the site.
@@ -25,12 +24,3 @@ The reference section holds the stable material that supports the rest of the si
     Follow the guidance for growing the documentation without losing coherence.
   </Card>
 </CardGroup>
-</div>
-
-## Use reference when you need
-
-<div className="gs-chip-row" role="list" aria-label="Reference use cases">
-  <span role="listitem">Definition</span>
-  <span role="listitem">Answer</span>
-  <span role="listitem">Guidance</span>
-</div>


### PR DESCRIPTION
## Summary
- applies the remaining GRO-29 content handoff items in a new PR branch
- converts targeted list-heavy sections to prose on practitioner/principles/playbook/case/reference pages
- normalizes hub-page intros to one lead paragraph and keeps copy aligned with Grounded Systems stance

## Scope
- index.mdx
- customers/index.mdx
- practitioners/index.mdx
- practitioners/who-thrives-here.mdx
- practitioners/how-we-think.mdx
- principles/index.mdx
- principles/anti-patterns.mdx
- principles/grounded-practitioners.mdx
- playbook/index.mdx
- playbook/entry-gate.mdx
- playbook/decision-patterns.mdx
- playbook/field-signals.mdx
- playbook/working-in-the-open.mdx
- playbook/taper-and-exit.mdx
- cases/index.mdx
- cases/legacy-modernization.mdx
- cases/vendor-friction.mdx
- cases/platform-seams.mdx
- reference/index.mdx
- reference/contribution-model.mdx

## Notes
PR #7 is already merged to main; this PR carries the remaining handoff refinements requested in GRO-29.