### PR TITLE
docs(content): apply GRO-31 paragraph-first content pass

### DIFF
--- a/cases/index.mdx
+++ b/cases/index.mdx
@@ -7,12 +7,7 @@ The cases show how the model behaves when real constraints and organizational se
 
 ## What the cases help you see
 
-Use them to understand:
-
-- where the real constraint often lives
-- what kind of first move lowers risk and increases clarity
-- which forms of drift or dependency need to be avoided
-- what capability should remain after the intervention
+Use them to understand where the real constraint often lives, what kind of first move lowers risk and increases clarity, which forms of drift or dependency should be avoided, and what capability should remain with the team after the intervention.
 
 ## Current cases
 
@@ -30,9 +25,4 @@ Use them to understand:
 
 ## How to read them
 
-A useful case should help answer four questions:
-
-- what was actually hard
-- where ownership lived
-- what move reduced friction
-- what the team could carry forward afterward
+A useful case should help answer four practical questions: what was actually hard, where ownership really lived, what move reduced friction in the current system, and what the team could carry forward afterward without extra outside control.

--- a/customers/index.mdx
+++ b/customers/index.mdx
@@ -7,13 +7,7 @@ Grounded Systems fits organizations that need real progress in systems they alre
 
 ## Where we help most
 
-We are most useful when teams are dealing with problems like these:
-
-- delivery is slower or more fragile than it should be
-- the system is hard to change safely
-- ownership is split across teams or hidden behind process
-- important decisions keep getting pushed outward instead of made close to the work
-- modernization is necessary, but a clean restart is unrealistic
+We are most useful when delivery is slower or more fragile than it should be, even though people are working hard and the system still matters to the business. In these environments, ownership is often spread across teams, vendors, or approval paths, so important decisions keep getting pushed away from the people closest to the work. Modernization is clearly needed, but a clean restart is not realistic and a parallel track would increase risk before reducing it.
 
 ## How the work works
 
@@ -25,11 +19,7 @@ The goal is not to become your delivery engine. The goal is to help your own tea
 
 ## What good clients should expect
 
-- practical movement inside the current system
-- clear reasoning and visible trade-offs
-- shared work rather than outside substitution
-- growing confidence and judgment in the host team
-- an exit path designed into the engagement
+A good engagement should feel practical rather than theatrical. You should see visible movement inside the current system, clear reasoning around trade-offs, and shared work that keeps your team central instead of treating it as a recipient. Over time, confidence and local judgment should increase, and the path to taper and exit should get clearer rather than more distant.
 
 ## Start with the right path
 

--- a/playbook/decision-patterns.mdx
+++ b/playbook/decision-patterns.mdx
@@ -11,12 +11,7 @@ In this model, a good decision is not the most impressive one. It is the one tha
 
 Most bad decisions start by treating the loudest symptom as the problem. Start by locating what repeatedly slows the system down, then decide from that point instead of from surface noise.
 
-Useful prompts:
-
-- What is actually making this hard?
-- Where does progress stall repeatedly?
-- Is this local execution pain, or a seam between teams?
-- What would still be true if this symptom disappeared tomorrow?
+Useful prompts include asking what is actually making this hard, where progress stalls repeatedly, whether the issue is local execution pain or a seam between teams, and what would still be true if the visible symptom disappeared tomorrow.
 
 ## Choose moves that are safe to learn from
 
@@ -28,11 +23,7 @@ Good early moves are safe to try, cheap to reverse, small enough to learn from q
 
 Extra structure can look responsible while quietly increasing ownership burden. Before adding layers, check whether the current path can be clarified, reduced, or made easier to operate.
 
-Ask:
-
-- Can we remove friction instead of adding process?
-- Can we improve an existing tool before introducing another one?
-- Will this be easier to own at 02:00?
+Before adding structure, ask whether we can remove friction instead of adding process, improve an existing tool before introducing another one, and make the path easier to own at 02:00.
 
 ## Follow ownership before tooling
 
@@ -54,7 +45,4 @@ A useful first move should directly show customer participation, practical depen
 
 ## Useful default questions
 
-- Will this leave the client more capable after we leave?
-- Does this reduce future dependence or deepen it?
-- Are we improving the real system or building around it?
-- Is this choice clarifying the work or decorating it?
+Keep four default checks in view: will this leave the client more capable after we leave, does it reduce future dependence or deepen it, are we improving the real system or building around it, and is this choice clarifying the work or only decorating it.

--- a/playbook/discovery.mdx
+++ b/playbook/discovery.mdx
@@ -25,11 +25,7 @@ Sponsors, delivery teams, platform groups, and managers often use the same word 
 
 ## Useful discovery questions
 
-- What is hard here that should not be this hard?
-- Where does work slow down repeatedly?
-- What still depends on outsiders for routine movement?
-- What would stay fragile even if throughput improved next month?
-- What would make this team less dependent six months from now?
+Useful discovery questions force the underlying pattern into the open: what is hard here that should not be this hard, where work slows down repeatedly, what still depends on outsiders for routine movement, what would remain fragile even if throughput improved next month, and what would make this team less dependent six months from now.
 
 ## Failure mode to avoid
 

--- a/playbook/entry-gate.mdx
+++ b/playbook/entry-gate.mdx
@@ -35,18 +35,11 @@ Typical blockers include platform gatekeeping with no room to negotiate, vendor 
 
 ## Questions to ask early
 
-- Who actually owns the backlog?
-- Who can approve technical direction?
-- Who operates the system when things go wrong?
-- What would the sponsor call "success" after three months?
-- What would still depend on us if the engagement ended abruptly?
+Ask early who actually owns backlog and delivery decisions, who can approve technical direction, and who operates the system when things go wrong. Clarify what the sponsor would call success after three months in plain language, then ask what would still depend on outside help if the engagement ended abruptly.
 
 ## Red flags
 
-- "We mainly need experienced hands to move faster"
-- "The team is too busy to be involved deeply"
-- "Ownership is still a bit unclear"
-- "We'll figure out taper later"
+Red flags usually show up in language before they show up in outcomes. Phrases like "we mainly need experienced hands to move faster," "the team is too busy to be involved deeply," "ownership is still a bit unclear," or "we will figure out taper later" usually mean capability and ownership are not actually the center of the engagement.
 
 ## Decision rule
 

--- a/playbook/index.mdx
+++ b/playbook/index.mdx
@@ -7,20 +7,13 @@ The playbook turns the stance into practical moves for real environments. It hel
 
 ## What you will find here
 
-- entry gate checks
-- discovery guidance for reading the real system
-- decision patterns for choosing safe, useful moves
-- field signals that show where friction and drift are hiding
-- sponsor behavior
-- ways of working in the open
-- taper and exit
-- lightweight checklists to support judgment
+This section helps practitioners decide whether to enter, how to read the real system, and how to choose moves that are safe, useful, and ownable. It also covers the signals that reveal drift, the sponsor behaviors that shape outcomes, how to work in the open without turning it into theater, how to taper and exit deliberately, and where simple checklists can catch misses when pressure rises.
 
 ## How to use it
 
 Use this section to support decisions in context.
 
-The goal is not to copy visible practices from page to page. The goal is to make better calls inside the real system, with the real team, under real constraints.
+The goal is not to copy visible practices from page to page or imitate ritual. The goal is to make better calls inside the real system, with the real team, under real constraints, and to build applied judgment that holds after outside presence tapers.
 
 ## Start with the right move
 

--- a/playbook/sponsor-behavior.mdx
+++ b/playbook/sponsor-behavior.mdx
@@ -33,13 +33,7 @@ A good sponsor can say, in plain language, what the work is meant to improve and
 
 ## Warning signs
 
-The sponsor becomes a risk when they:
-
-- ask for speed but not ownership
-- avoid conflict with neighboring groups
-- describe the outside unit as senior firepower
-- focus reporting on delivery volume alone
-- allow taper to slip indefinitely
+The sponsor becomes a risk when speed is emphasized without ownership, when cross-team conflict is avoided instead of worked, when the outside unit is framed as senior firepower, when reporting narrows to delivery volume alone, or when taper keeps slipping without a practical reason. Sponsor drift is often gradual and linguistic before it is explicit, so naming it early matters.
 
 ## Practical check
 

--- a/playbook/taper-and-exit.mdx
+++ b/playbook/taper-and-exit.mdx
@@ -31,11 +31,7 @@ The team continues without prompting, trade-offs are articulated clearly, blocke
 
 ## Exit notes should cover
 
-- what changed
-- what the team now owns
-- where remaining friction still lives
-- what to watch for next
-- when a short return would make sense
+A useful exit note explains what changed, what the team now owns directly, where remaining friction still lives, what to watch next, and when a short return would make sense.
 
 ## Return is allowed
 

--- a/playbook/working-in-the-open.mdx
+++ b/playbook/working-in-the-open.mdx
@@ -5,9 +5,7 @@ description: How visibility, shared reasoning, and open seams reduce friction an
 
 Working in the open means making the real work visible enough that other people can understand what is happening, why it is happening, and where friction still lives.
 
-This is not performance.
-It is not status reporting theater.
-It is a practical way to reduce confusion, surface trade-offs, and strengthen ownership across boundaries.
+It is not performance or status reporting theater. It is a practical way to reduce confusion, surface trade-offs, and strengthen ownership across boundaries.
 
 ## Why it matters
 
@@ -33,14 +31,7 @@ Good open work uses simple language, visible intent, clear ownership, and enough
 
 ## What this is not
 
-Working in the open does not mean:
-
-- documenting everything
-- broadcasting every thought
-- forcing people into performative transparency
-- replacing judgment with process
-
-The point is to reduce hidden dependency, not create more administrative weight.
+Working in the open does not mean documenting everything, broadcasting every thought, forcing people into performative transparency, or replacing judgment with process. The point is to reduce hidden dependency, not create more administrative weight.
 
 ## Common failure modes
 

--- a/practitioners/index.mdx
+++ b/practitioners/index.mdx
@@ -7,14 +7,7 @@ This work fits practitioners who can enter a real environment, read what is actu
 
 ## The kind of practitioner who tends to fit
 
-People who thrive here are usually:
-
-- calm in messy environments
-- curious before certain
-- practical in both language and action
-- able to teach while doing
-- comfortable working across technical and organizational seams
-- willing to challenge assumptions without making themselves the center of gravity
+People who thrive here tend to stay calm in messy environments, get curious before they get certain, and keep both their language and their moves practical. They can teach while doing real work, move across technical and organizational seams without getting performative, and challenge assumptions without making themselves the center of gravity.
 
 ## What the work asks of you
 

--- a/principles/index.mdx
+++ b/principles/index.mdx
@@ -7,13 +7,9 @@ These principles keep the work honest when pressure rises. They protect customer
 
 ## The principles
 
-- **Customer ownership comes first.** Client teams own backlog, decisions, delivery, and operations from day one.
-- **Modernize in place.** Start where the value already lives instead of defaulting to parallel replacement.
-- **Capability matters more than output volume.** Progress only counts if the customer becomes more able to continue without us.
-- **Tools follow context.** Tooling choices should lower friction and be clearly owned, not act as transformation theater.
-- **Simplicity and reversibility first.** Prefer moves that are easier to explain, easier to operate, and cheaper to undo.
-- **Work in the open.** Keep reasoning, trade-offs, and ownership visible near the work.
-- **Design exit into the model.** If success depends on permanent outside presence, the engagement has drifted.
+Customer ownership comes first, which means client teams stay responsible for backlog, decisions, delivery, and operations from day one. Modernize in place means change starts where value already lives, not in a parallel world that delays contact with real constraints. Capability matters more than output volume, so progress only counts when the customer becomes more able to continue without us.
+
+Tools follow context, not the other way around. A tool choice is good when it lowers friction and has clear ownership, not when it creates a cleaner story. Simplicity and reversibility come before heavy solutions because they lower the cost of being wrong and keep operations clearer at pressure points. Work in the open keeps trade-offs and ownership visible near the work, and exit must be designed in from the start so the model does not drift into permanent outside centrality.
 
 ## Explore the principle set
 
@@ -36,4 +32,4 @@ These principles keep the work honest when pressure rises. They protect customer
 
 A lot of modernization effort fails for the same reason: it creates visible movement without leaving behind judgment, confidence, or durable ownership.
 
-These principles exist to prevent that failure mode.
+These principles are practical constraints, not values language. They exist to prevent predictable drift toward dependency, theater, and externalized modernization.

--- a/reference/contribution-model.mdx
+++ b/reference/contribution-model.mdx
@@ -11,22 +11,11 @@ This site is meant to stay useful under growth. That means adding material with 
 
 ## What belongs here
 
-Useful additions tend to do one of four things:
-
-- explain the model more clearly
-- make the model easier to use in practice
-- show how the model behaves in real situations
-- sharpen boundaries by naming traps and failure modes
+Useful additions usually do one of four things: explain the model more clearly, make the practice easier to apply, show how the model behaves in real situations, or sharpen boundaries by naming traps and failure modes.
 
 ## What does not belong here
 
-Avoid adding material that is:
-
-- generic consulting language
-- vague transformation rhetoric
-- thin opinion with no practical use
-- tool promotion without contextual reasoning
-- content that makes the site broader but weaker
+Avoid material that reads like generic consulting language, vague transformation rhetoric, thin opinion with no practical use, tool promotion without contextual reasoning, or content that makes the site broader but weaker.
 
 ## Writing rules
 
@@ -36,23 +25,12 @@ Write in plain language. Prefer simple words, short sections, direct statements,
 
 Page role matters because readers come here with different jobs to do: understanding the model, applying it, seeing it in practice, or checking a stable definition.
 
-When adding a page, decide first what role it plays:
-
-- public entrypoint
-- principle
-- playbook
-- case
-- reference
+When adding a page, decide first what role it plays: public entrypoint, principle, playbook, case, or reference.
 
 Do not mix all five roles into one page.
 
 ## Quality check
 
-Before adding content, ask:
-
-- Does this make the model clearer?
-- Does this make the practice more usable?
-- Does this protect the boundaries of the stance?
-- Would this still matter six months from now?
+Before adding content, ask whether it makes the model clearer, makes the practice more usable, protects the boundaries of the stance, and still matters six months from now.
 
 If the answer is no, do not add it.

--- a/reference/index.mdx
+++ b/reference/index.mdx
@@ -7,9 +7,7 @@ The reference section holds the stable material that keeps the rest of the site 
 
 ## What belongs here
 
-- glossary terms that keep the language clear and consistent
-- common questions with short, direct answers
-- contribution guidance for growing the site without drifting into noise
+This section holds glossary terms that keep language clear and consistent, common questions answered directly, and contribution guidance that helps the site grow without losing coherence. It is intentionally the most stable and least rhetorical part of the documentation.
 
 ## Start here
 


### PR DESCRIPTION
## Summary
- apply the GRO-30 verbose-content handoff to the remaining list-heavy sections in landing and guidance pages
- convert checklist-style explanatory bullets into paragraph-first prose while preserving card navigation structure
- keep reference/checklist utility pages list-shaped where appropriate

## Scope
- homepage-adjacent landing pages: customers, practitioners, principles, playbook, cases, reference
- supporting guidance pages: entry gate, discovery, decision patterns, sponsor behavior, working in the open, taper and exit, contribution model

## Validation
- attempted `npx mintlify@latest validate` but local Node is `v25.8.2` and Mintlify currently fails on 25+
