### PR TITLE
docs: expand explanatory prose on core pages

### DIFF
--- a/customers/how-we-work.mdx
+++ b/customers/how-we-work.mdx
@@ -7,18 +7,22 @@ We work from inside the real environment.
 
 That is more practical than it sounds. It means we join the work where the friction actually lives, with the people who already own the system, instead of building a polished answer somewhere else and hoping it lands.
 
+This matters because most modernization difficulty is not caused by missing ideas. It is caused by overloaded seams between teams, unclear decision rights, and changes that are hard to absorb in live operations. Working in the real environment keeps those realities visible and makes progress more reliable.
+
 ## How an engagement usually moves
 
 We start by understanding the real constraints: what cannot break, where ownership is fuzzy, and which seams keep slowing things down. Then we make one safe move in the existing system, not a grand redesign on a slide.
 
 From there, the work becomes shared. We pair while shipping, explain trade-offs in the open, and help the team build confidence in its own decisions. As that confidence grows, our role gets lighter on purpose. We move from doing, to pairing, to reviewing, to stepping back.
 
+As the engagement advances, we deliberately connect technical work to organizational clarity. A code change may also resolve an approval bottleneck. A release fix may also improve incident handoffs. A refactor may also simplify ownership boundaries between teams. The objective is durable movement across both the system and the way people operate it.
+
 ## What this should feel like
 
-A Grounded Systems engagement should feel practical, not theatrical. You should see progress inside the current system, clearer reasoning around decisions, and more confidence in the host team over time.
+A Grounded Systems engagement should feel practical and transparent. You should see progress inside the current system, clearer reasoning around decisions, and more confidence in the host team over time.
 
-You should not see hidden ownership, a surprise tool agenda, or an outside team quietly becoming the real delivery engine.
+You should also see a consistent handoff path taking shape: decisions becoming easier to trace, standards becoming easier to explain, and the host team becoming more comfortable handling pressure without depending on outside intervention.
 
 ## Why this matters
 
-The strongest improvements are the ones a client can still carry when we are no longer in the room.
+The strongest improvements are the ones a client can still carry when we are no longer in the room. That is what makes modernization economically useful: capability grows with delivery, and value keeps compounding after the engagement ends.

--- a/customers/index.mdx
+++ b/customers/index.mdx
@@ -9,17 +9,21 @@ Grounded Systems fits organizations that need real progress in systems they alre
 
 We are most useful when delivery is slower or more fragile than it should be, even though people are working hard and the system still matters to the business. In these environments, ownership is often spread across teams, vendors, or approval paths, so important decisions keep getting pushed away from the people closest to the work. Modernization is clearly needed, but a clean restart is not realistic and a parallel track would increase risk before reducing it.
 
+These conditions are common in operating companies: core systems hold years of business knowledge, compliance constraints are real, and every change has to coexist with live operations. The work matters because delay and ambiguity accumulate quietly. Teams spend more time coordinating than improving. Priorities shift faster than architecture can absorb. Grounded Systems is designed for this exact terrain.
+
 ## How the work works
 
 We embed as a small senior unit inside the real environment.
 
 That means we work with the team that owns the system, use the current tools and constraints as the starting point, and help create small but meaningful improvements that the team can keep carrying after we leave.
 
-The goal is not to become your delivery engine. The goal is to help your own teams become more capable, more confident, and more able to move without outside dependence.
+The goal is to help your own teams become more capable, more confident, and more able to move without outside dependence. Value appears both in delivery outcomes and in team capability: safer releases, clearer technical decisions, cleaner handoffs, and a stronger ability to decide what to do next without waiting for external direction.
 
 ## What good clients should expect
 
-A good engagement should feel practical rather than theatrical. You should see visible movement inside the current system, clear reasoning around trade-offs, and shared work that keeps your team central instead of treating it as a recipient. Over time, confidence and local judgment should increase, and the path to taper and exit should get clearer rather than more distant.
+A good engagement should feel practical and steady. You should see visible movement inside the current system, clear reasoning around trade-offs, and shared work that keeps your team central in decisions and execution.
+
+Over time, confidence and local judgment should increase. Leaders should have better visibility into where friction lives and why. Teams should feel more able to make hard calls with the context they already have. The path to taper and exit should become clearer as internal capability grows.
 
 ## Start with the right path
 
@@ -39,4 +43,4 @@ A good engagement should feel practical rather than theatrical. You should see v
 
 This model works best when leadership wants stronger internal capability, not just more external throughput.
 
-It also works best when the host team can own backlog, decisions, delivery, and operations while we are present. If those conditions are not there yet, the first step is usually to create them.
+It also works best when the host team can own backlog, decisions, delivery, and operations while we are present. When those conditions are still forming, we can begin by making ownership explicit and building the working agreements that let modernization move safely.

--- a/index.mdx
+++ b/index.mdx
@@ -9,7 +9,9 @@ Grounded Systems helps organizations modernize from within by working inside the
 
 Modernization usually stalls for a reason. The system is active, the constraints are real, and the team still has to run the business while change is happening.
 
-Grounded Systems is a small senior consulting capability that embeds where work is stuck and helps teams make practical progress in place. We do not build a separate track of change around the customer. We work with the existing team, inside the existing environment, and design the work so outside presence tapers over time.
+Grounded Systems is a small senior consulting capability that embeds where work is stuck and helps teams make practical progress in place. We work with the existing team, inside the existing environment, and design the work so outside presence tapers over time.
+
+In practice, that means early work usually starts with friction that is already visible to the business: release delays, handoff confusion, recurring incidents, or decision seams that slow teams down. We make these seams explicit, improve one area at a time, and keep decisions near the people responsible for outcomes. This creates progress that stays connected to operations, rather than progress that only looks good in a separate delivery lane.
 
 ## Start where you fit
 
@@ -38,8 +40,8 @@ Grounded Systems is a small senior consulting capability that embeds where work 
 
 This work helps teams make safer progress in systems that already carry real value. It brings ownership closer to the work, improves technical and organizational judgment, and reduces the need for outside delivery over time. The aim is not a burst of activity while we are present. It is modernization that still holds after we leave.
 
-## Why this model feels different
+## Why this model matters
 
-Many modernization efforts create movement first and capability later, if it arrives at all. A new platform appears. A parallel system gets built. Another team ships the change. The customer is still left depending on someone else to keep it moving.
+When modernization is handled close to the real system, teams get faster feedback on what works in production conditions. They develop stronger local judgment, clearer decision ownership, and more confidence in making trade-offs under pressure. Over time, this changes more than architecture. It improves how the organization coordinates, decides, and delivers.
 
-Grounded Systems works the other way around. We help teams learn while shipping, keep trade-offs visible, and strengthen the habits that let them continue on their own.
+The long-term value is operational: fewer avoidable escalations, less churn from unclear ownership, and a modernization path that the host team can keep carrying as priorities change.

--- a/playbook/index.mdx
+++ b/playbook/index.mdx
@@ -5,15 +5,21 @@ description: Practical guidance for entering, navigating, and exiting real moder
 
 The playbook turns the stance into practical moves for real environments. It helps you decide when to enter, what to notice, and how to move without creating new dependency.
 
+It exists because good intent is not enough under delivery pressure. Teams need a way to make consistent decisions when context is messy, timelines are tight, and trade-offs are not clean. The playbook provides that consistency without turning practice into rigid process.
+
 ## What you will find here
 
 This section helps practitioners decide whether to enter, how to read the real system, and how to choose moves that are safe, useful, and ownable. It also covers the signals that reveal drift, the sponsor behaviors that shape outcomes, how to work in the open without turning it into theater, how to taper and exit deliberately, and where simple checklists can catch misses when pressure rises.
+
+Each guide is built to answer a practical question in sequence: Should we start? What are we actually seeing? What is the safest next move? Who needs to decide? What signals suggest correction? How do we leave the system stronger than we found it? Read together, these pages form an operating thread from first engagement through exit.
 
 ## How to use it
 
 Use this section to support decisions in context.
 
 The goal is not to copy visible practices from page to page or imitate ritual. The goal is to make better calls inside the real system, with the real team, under real constraints, and to build applied judgment that holds after outside presence tapers.
+
+Treat each page as a decision aid. Bring one active situation to the guide, test your assumptions, and choose the next step you can execute safely this week. The value of the playbook comes from repeated use in real work, where choices accumulate into stronger ownership and steadier delivery.
 
 ## Start with the right move
 


### PR DESCRIPTION
## Summary

Expands grounded explanatory prose on key entry pages to better explain why the model matters, how work is carried out, and where customer value appears in practice.

## Changes

- `index.mdx`: expanded practical framing and long-term value explanation
- `customers/index.mdx`: added clearer customer-context prose and expected outcomes
- `customers/how-we-work.mdx`: expanded operational explanation of engagement flow and handoff behavior
- `playbook/index.mdx`: added deeper usage guidance and decision-thread framing

## Validation

- JSON control files parse cleanly: `docs.json`, `config/navigation.json`
- `mint validate` currently blocked locally because Node is `25.8.2` and Mintlify requires `<26`

Related issue: [GRO-32](https://github.com/lagebj/docs/issues/32)