### PR TITLE
docs(content): add reader-guidance layer to long-form pages

### DIFF
--- a/customers/what-we-help-with.mdx
+++ b/customers/what-we-help-with.mdx
@@ -5,15 +5,33 @@ description: The kinds of situations Grounded Systems is built to help improve.
 
 Grounded Systems is built for situations where progress is needed, but the current path is producing fragility, dependence, or slow movement.
 
+<p className="gs-lead">
+  The pattern is usually clear: important systems still carry real value, but the current delivery and decision flow makes change heavier than it should be.
+</p>
+
+<div className="gs-overview-band">
+  <div className="gs-chip-row">
+    <span>Repeated delivery drag</span>
+    <span>Blurry ownership seams</span>
+    <span>Externalized modernization</span>
+  </div>
+</div>
+
 ## Typical situations
 
 Grounded Systems is most useful when the system still matters, but the current way of changing it keeps creating drag.
 
-**Delivery is slower or riskier than it should be.** Teams are working hard, but every change feels heavier than it ought to.
-
-**Ownership is split or blurry.** Decisions bounce between teams, vendors, platforms, or approval paths, so the real problem never sits still long enough to get solved.
-
-**Modernization keeps getting externalized.** The answer keeps becoming a separate track, a future migration, or an outside effort that helps for a while without improving the customer's own capability.
+<CardGroup cols={3}>
+  <Card title="Delivery is slower or riskier than it should be">
+    Teams are working hard, but every change feels heavier than it ought to.
+  </Card>
+  <Card title="Ownership is split or blurry">
+    Decisions bounce between teams, vendors, platforms, or approval paths, so the real problem never sits still long enough to get solved.
+  </Card>
+  <Card title="Modernization keeps getting externalized">
+    The answer keeps becoming a separate track, a future migration, or an outside effort that helps for a while without improving the customer's own capability.
+  </Card>
+</CardGroup>
 
 ## What usually sits underneath
 

--- a/playbook/discovery.mdx
+++ b/playbook/discovery.mdx
@@ -7,6 +7,19 @@ Discovery is the work of understanding the real environment before prescribing c
 
 It is how you learn where change gets stuck, who carries the real risk, what cannot break, and what the organization is quietly optimizing for beneath the official story.
 
+<p className="gs-lead">
+  Good discovery does not produce a polished diagnosis deck. It makes the real constraints visible early enough to choose safer moves.
+</p>
+
+<div className="gs-overview-band">
+  <div className="gs-chip-row">
+    <span>Read repeated patterns</span>
+    <span>Clarify real ownership</span>
+    <span>Name protected constraints</span>
+    <span>Separate success definitions</span>
+  </div>
+</div>
+
 ## Find where friction keeps repeating
 
 Look for repeated delays, fragile handoffs, and decision loops that never close. The repeated pattern usually matters more than any single incident.
@@ -25,8 +38,23 @@ Sponsors, delivery teams, platform groups, and managers often use the same word 
 
 ## Useful discovery questions
 
-Useful discovery questions force the underlying pattern into the open: what is hard here that should not be this hard, where work slows down repeatedly, what still depends on outsiders for routine movement, what would remain fragile even if throughput improved next month, and what would make this team less dependent six months from now.
+<CardGroup cols={2}>
+  <Card title="Pressure points">
+    What is hard here that should not be this hard?
+  </Card>
+  <Card title="Repeated slowdowns">
+    Where does work slow down in the same way every week?
+  </Card>
+  <Card title="Dependency check">
+    What still depends on outsiders for routine movement?
+  </Card>
+  <Card title="Durability check">
+    What would remain fragile even if throughput improved next month, and what would make this team less dependent six months from now?
+  </Card>
+</CardGroup>
 
 ## Failure mode to avoid
 
-Bad discovery jumps from symptom to solution shape too quickly. If the tooling discussion becomes clearer than the ownership discussion, discovery is not complete.
+<Callout type="warning" title="Do not jump from symptom to solution shape">
+  If the tooling discussion becomes clearer than the ownership discussion, discovery is not complete.
+</Callout>

--- a/principles/core-principles.mdx
+++ b/principles/core-principles.mdx
@@ -5,6 +5,19 @@ description: The non-negotiable principles behind Grounded Systems.
 
 These principles define the stance. They are not decoration. They exist to keep the work from drifting into delivery theater, consultant dependency, or tool-led confusion.
 
+<p className="gs-lead">
+  The principle set is a practical operating boundary: keep ownership with the customer, modernize inside the real system, and choose moves teams can maintain under pressure.
+</p>
+
+<div className="gs-overview-band">
+  <div className="gs-chip-row">
+    <span>Ownership first</span>
+    <span>Capability over dependency</span>
+    <span>Modernize in place</span>
+    <span>Simple and reversible</span>
+  </div>
+</div>
+
 ## 1. Customer ownership always
 
 The client team must own goals, backlog, design, operations, and system shape.

--- a/style.css
+++ b/style.css
@@ -1,10 +1,12 @@
 :root {
   --gs-brand-blue: #1d4ed8;
+  --gs-brand-blue-strong: #1e40af;
   --gs-brand-slate: #334155;
   --gs-chrome-shadow: 0 14px 34px rgba(30, 64, 175, 0.12);
   --gs-border-muted: rgba(51, 65, 85, 0.2);
   --gs-surface-soft: linear-gradient(180deg, rgba(219, 234, 254, 0.5) 0%, rgba(248, 250, 252, 0.96) 100%);
   --gs-surface-band: linear-gradient(180deg, rgba(191, 219, 254, 0.42) 0%, rgba(241, 245, 249, 0.92) 100%);
+  --gs-active-surface: rgba(219, 234, 254, 0.54);
   --gs-space-vertical: clamp(2.5rem, 2rem + 1vw, 3.5rem);
 }
 
@@ -179,6 +181,38 @@ body:has(.gs-hub-page) .sidebar .sidebar-item[aria-current="page"] {
 .toc {
   border-left: 1px solid var(--gs-border-muted);
   padding-left: 1rem;
+}
+
+.sidebar .sidebar-item[aria-current="page"],
+.sidebar a[aria-current="page"] {
+  background: var(--gs-active-surface);
+  color: var(--gs-brand-blue-strong);
+  border-radius: 8px;
+  font-weight: 700;
+  border-left: 2px solid rgba(30, 64, 175, 0.55);
+  padding-left: calc(0.75rem - 2px);
+}
+
+.sidebar .sidebar-item[aria-current="page"] .group-label,
+.sidebar a[aria-current="page"] .group-label {
+  color: var(--gs-brand-blue-strong);
+}
+
+.toc a[aria-current="true"],
+.toc a[aria-current="location"],
+.toc a.active {
+  color: var(--gs-brand-blue-strong);
+  font-weight: 700;
+  text-decoration: none;
+  border-left: 2px solid rgba(30, 64, 175, 0.5);
+  margin-left: -1rem;
+  padding-left: calc(1rem - 2px);
+}
+
+.toc a[aria-current="true"]::before,
+.toc a[aria-current="location"]::before,
+.toc a.active::before {
+  background: var(--gs-brand-blue-strong);
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary

Implements the GRO-34 reader-guidance pass on scoped long-form pages with restrained global orientation polish.

### Changes

- Add lead + signal layer + card-based scan improvements in `customers/what-we-help-with.mdx`
- Add lead + signal layer + card-based question block + warning callout in `playbook/discovery.mdx`
- Add lead + signal layer in `principles/core-principles.mdx`
- Strengthen active-state legibility for sidebar and TOC in `style.css`

### Verification

- Local preview run with LTS Node (`node@20`)
- Checked `/`, `/playbook/discovery`, `/principles/core-principles` return 200
- Root-page `TypeError: Invalid URL` was not reproduced in this LTS run

Refs: [GRO-34](https://github.com/lagebj/docs/issues/34)