### PR TITLE
docs(content): add reader-guidance layer to long-form pages

### DIFF
--- a/customers/what-we-help-with.mdx
+++ b/customers/what-we-help-with.mdx
@@ -5,15 +5,33 @@ description: The kinds of situations Grounded Systems is built to help improve.
 
 Grounded Systems is built for situations where progress is needed, but the current path is producing fragility, dependence, or slow movement.
 
+<p className="gs-lead">
+  The pattern is usually clear: important systems still carry real value, but the current delivery and decision flow makes change heavier than it should be.
+</p>
+
+<div className="gs-overview-band">
+  <div className="gs-chip-row">
+    <span>Repeated delivery drag</span>
+    <span>Blurry ownership seams</span>
+    <span>Externalized modernization</span>
+  </div>
+</div>
+
 ## Typical situations
 
 Grounded Systems is most useful when the system still matters, but the current way of changing it keeps creating drag.
 
-**Delivery is slower or riskier than it should be.** Teams are working hard, but every change feels heavier than it ought to.
-
-**Ownership is split or blurry.** Decisions bounce between teams, vendors, platforms, or approval paths, so the real problem never sits still long enough to get solved.
-
-**Modernization keeps getting externalized.** The answer keeps becoming a separate track, a future migration, or an outside effort that helps for a while without improving the customer's own capability.
+<CardGroup cols={3}>
+  <Card title="Delivery is slower or riskier than it should be">
+    Teams are working hard, but every change feels heavier than it ought to.
+  </Card>
+  <Card title="Ownership is split or blurry">
+    Decisions bounce between teams, vendors, platforms, or approval paths, so the real problem never sits still long enough to get solved.
+  </Card>
+  <Card title="Modernization keeps getting externalized">
+    The answer keeps becoming a separate track, a future migration, or an outside effort that helps for a while without improving the customer's own capability.
+  </Card>
+</CardGroup>
 
 ## What usually sits underneath
 

--- a/customers/what-we-help-with.mdx
+++ b/customers/what-we-help-with.mdx
@@ -9,29 +9,21 @@ Grounded Systems is built for situations where progress is needed, but the curre
   The pattern is usually clear: important systems still carry real value, but the current delivery and decision flow makes change heavier than it should be.
 </p>
 
-<div className="gs-overview-band">
-  <div className="gs-chip-row">
-    <span>Repeated delivery drag</span>
-    <span>Blurry ownership seams</span>
-    <span>Externalized modernization</span>
-  </div>
-</div>
-
 ## Typical situations
 
 Grounded Systems is most useful when the system still matters, but the current way of changing it keeps creating drag.
 
-<CardGroup cols={3}>
-  <Card title="Delivery is slower or riskier than it should be">
-    Teams are working hard, but every change feels heavier than it ought to.
-  </Card>
-  <Card title="Ownership is split or blurry">
-    Decisions bounce between teams, vendors, platforms, or approval paths, so the real problem never sits still long enough to get solved.
-  </Card>
-  <Card title="Modernization keeps getting externalized">
-    The answer keeps becoming a separate track, a future migration, or an outside effort that helps for a while without improving the customer's own capability.
-  </Card>
-</CardGroup>
+### Delivery is slower or riskier than it should be
+
+<span className="gs-label">What this looks like:</span> teams are working hard, but routine changes still feel heavier than they should.
+
+### Ownership is split or blurry
+
+<span className="gs-label">What this looks like:</span> decisions bounce between teams, vendors, platform groups, or approval paths, so the real problem never sits still long enough to get solved.
+
+### Modernization keeps getting externalized
+
+<span className="gs-label">What this looks like:</span> the answer keeps becoming a separate track, a future migration, or an outside effort that helps temporarily without improving customer capability.
 
 ## What usually sits underneath
 

--- a/playbook/discovery.mdx
+++ b/playbook/discovery.mdx
@@ -11,15 +11,6 @@ It is how you learn where change gets stuck, who carries the real risk, what can
   Good discovery does not produce a polished diagnosis deck. It makes the real constraints visible early enough to choose safer moves.
 </p>
 
-<div className="gs-overview-band">
-  <div className="gs-chip-row">
-    <span>Read repeated patterns</span>
-    <span>Clarify real ownership</span>
-    <span>Name protected constraints</span>
-    <span>Separate success definitions</span>
-  </div>
-</div>
-
 ## Find where friction keeps repeating
 
 Look for repeated delays, fragile handoffs, and decision loops that never close. The repeated pattern usually matters more than any single incident.
@@ -38,23 +29,11 @@ Sponsors, delivery teams, platform groups, and managers often use the same word 
 
 ## Useful discovery questions
 
-<CardGroup cols={2}>
-  <Card title="Pressure points">
-    What is hard here that should not be this hard?
-  </Card>
-  <Card title="Repeated slowdowns">
-    Where does work slow down in the same way every week?
-  </Card>
-  <Card title="Dependency check">
-    What still depends on outsiders for routine movement?
-  </Card>
-  <Card title="Durability check">
-    What would remain fragile even if throughput improved next month, and what would make this team less dependent six months from now?
-  </Card>
-</CardGroup>
+- <span className="gs-label">Pressure points:</span> What is hard here that should not be this hard?
+- <span className="gs-label">Repeated slowdowns:</span> Where does work slow down in the same way every week?
+- <span className="gs-label">Dependency check:</span> What still depends on outsiders for routine movement?
+- <span className="gs-label">Durability check:</span> What would remain fragile even if throughput improved next month, and what would make this team less dependent six months from now?
 
 ## Failure mode to avoid
 
-<Callout type="warning" title="Do not jump from symptom to solution shape">
-  If the tooling discussion becomes clearer than the ownership discussion, discovery is not complete.
-</Callout>
+<span className="gs-label">Failure mode:</span> if the tooling discussion becomes clearer than the ownership discussion, discovery is not complete.

--- a/playbook/discovery.mdx
+++ b/playbook/discovery.mdx
@@ -7,6 +7,19 @@ Discovery is the work of understanding the real environment before prescribing c
 
 It is how you learn where change gets stuck, who carries the real risk, what cannot break, and what the organization is quietly optimizing for beneath the official story.
 
+<p className="gs-lead">
+  Good discovery does not produce a polished diagnosis deck. It makes the real constraints visible early enough to choose safer moves.
+</p>
+
+<div className="gs-overview-band">
+  <div className="gs-chip-row">
+    <span>Read repeated patterns</span>
+    <span>Clarify real ownership</span>
+    <span>Name protected constraints</span>
+    <span>Separate success definitions</span>
+  </div>
+</div>
+
 ## Find where friction keeps repeating
 
 Look for repeated delays, fragile handoffs, and decision loops that never close. The repeated pattern usually matters more than any single incident.
@@ -25,8 +38,23 @@ Sponsors, delivery teams, platform groups, and managers often use the same word 
 
 ## Useful discovery questions
 
-Useful discovery questions force the underlying pattern into the open: what is hard here that should not be this hard, where work slows down repeatedly, what still depends on outsiders for routine movement, what would remain fragile even if throughput improved next month, and what would make this team less dependent six months from now.
+<CardGroup cols={2}>
+  <Card title="Pressure points">
+    What is hard here that should not be this hard?
+  </Card>
+  <Card title="Repeated slowdowns">
+    Where does work slow down in the same way every week?
+  </Card>
+  <Card title="Dependency check">
+    What still depends on outsiders for routine movement?
+  </Card>
+  <Card title="Durability check">
+    What would remain fragile even if throughput improved next month, and what would make this team less dependent six months from now?
+  </Card>
+</CardGroup>
 
 ## Failure mode to avoid
 
-Bad discovery jumps from symptom to solution shape too quickly. If the tooling discussion becomes clearer than the ownership discussion, discovery is not complete.
+<Callout type="warning" title="Do not jump from symptom to solution shape">
+  If the tooling discussion becomes clearer than the ownership discussion, discovery is not complete.
+</Callout>

--- a/principles/core-principles.mdx
+++ b/principles/core-principles.mdx
@@ -5,6 +5,19 @@ description: The non-negotiable principles behind Grounded Systems.
 
 These principles define the stance. They are not decoration. They exist to keep the work from drifting into delivery theater, consultant dependency, or tool-led confusion.
 
+<p className="gs-lead">
+  The principle set is a practical operating boundary: keep ownership with the customer, modernize inside the real system, and choose moves teams can maintain under pressure.
+</p>
+
+<div className="gs-overview-band">
+  <div className="gs-chip-row">
+    <span>Ownership first</span>
+    <span>Capability over dependency</span>
+    <span>Modernize in place</span>
+    <span>Simple and reversible</span>
+  </div>
+</div>
+
 ## 1. Customer ownership always
 
 The client team must own goals, backlog, design, operations, and system shape.

--- a/principles/core-principles.mdx
+++ b/principles/core-principles.mdx
@@ -9,15 +9,6 @@ These principles define the stance. They are not decoration. They exist to keep 
   The principle set is a practical operating boundary: keep ownership with the customer, modernize inside the real system, and choose moves teams can maintain under pressure.
 </p>
 
-<div className="gs-overview-band">
-  <div className="gs-chip-row">
-    <span>Ownership first</span>
-    <span>Capability over dependency</span>
-    <span>Modernize in place</span>
-    <span>Simple and reversible</span>
-  </div>
-</div>
-
 ## 1. Customer ownership always
 
 The client team must own goals, backlog, design, operations, and system shape.

--- a/style.css
+++ b/style.css
@@ -1,10 +1,12 @@
 :root {
   --gs-brand-blue: #1d4ed8;
+  --gs-brand-blue-strong: #1e40af;
   --gs-brand-slate: #334155;
   --gs-chrome-shadow: 0 14px 34px rgba(30, 64, 175, 0.12);
   --gs-border-muted: rgba(51, 65, 85, 0.2);
   --gs-surface-soft: linear-gradient(180deg, rgba(219, 234, 254, 0.5) 0%, rgba(248, 250, 252, 0.96) 100%);
   --gs-surface-band: linear-gradient(180deg, rgba(191, 219, 254, 0.42) 0%, rgba(241, 245, 249, 0.92) 100%);
+  --gs-active-surface: rgba(219, 234, 254, 0.54);
   --gs-space-vertical: clamp(2.5rem, 2rem + 1vw, 3.5rem);
 }
 
@@ -179,6 +181,38 @@ body:has(.gs-hub-page) .sidebar .sidebar-item[aria-current="page"] {
 .toc {
   border-left: 1px solid var(--gs-border-muted);
   padding-left: 1rem;
+}
+
+.sidebar .sidebar-item[aria-current="page"],
+.sidebar a[aria-current="page"] {
+  background: var(--gs-active-surface);
+  color: var(--gs-brand-blue-strong);
+  border-radius: 8px;
+  font-weight: 700;
+  border-left: 2px solid rgba(30, 64, 175, 0.55);
+  padding-left: calc(0.75rem - 2px);
+}
+
+.sidebar .sidebar-item[aria-current="page"] .group-label,
+.sidebar a[aria-current="page"] .group-label {
+  color: var(--gs-brand-blue-strong);
+}
+
+.toc a[aria-current="true"],
+.toc a[aria-current="location"],
+.toc a.active {
+  color: var(--gs-brand-blue-strong);
+  font-weight: 700;
+  text-decoration: none;
+  border-left: 2px solid rgba(30, 64, 175, 0.5);
+  margin-left: -1rem;
+  padding-left: calc(1rem - 2px);
+}
+
+.toc a[aria-current="true"]::before,
+.toc a[aria-current="location"]::before,
+.toc a.active::before {
+  background: var(--gs-brand-blue-strong);
 }
 
 @media (max-width: 768px) {

--- a/style.css
+++ b/style.css
@@ -5,7 +5,6 @@
   --gs-chrome-shadow: 0 14px 34px rgba(30, 64, 175, 0.12);
   --gs-border-muted: rgba(51, 65, 85, 0.2);
   --gs-surface-soft: linear-gradient(180deg, rgba(219, 234, 254, 0.5) 0%, rgba(248, 250, 252, 0.96) 100%);
-  --gs-surface-band: linear-gradient(180deg, rgba(191, 219, 254, 0.42) 0%, rgba(241, 245, 249, 0.92) 100%);
   --gs-active-surface: rgba(219, 234, 254, 0.54);
   --gs-space-vertical: clamp(2.5rem, 2rem + 1vw, 3.5rem);
 }
@@ -43,35 +42,34 @@
 .prose h2 {
   color: #0f172a;
   letter-spacing: -0.01em;
-  margin-top: 2rem;
+  margin-top: 2.4rem;
+  margin-bottom: 0.8rem;
 }
 
 .prose h3 {
   color: #1e293b;
+  margin-top: 1.65rem;
+  margin-bottom: 0.45rem;
+}
+
+.prose p {
+  max-width: 72ch;
+  line-height: 1.72;
+  margin: 0.85rem 0;
 }
 
 .gs-lead {
   font-size: clamp(1.04rem, 0.96rem + 0.35vw, 1.26rem);
+  color: #0f172a;
+  font-weight: 600;
   line-height: 1.55;
   max-width: 70ch;
-  margin-bottom: 1.3rem;
+  margin: 0.55rem 0 1.35rem;
 }
 
-.gs-overview-band {
-  margin: 1.7rem 0 2rem;
-  padding: clamp(0.9rem, 0.8rem + 0.5vw, 1.35rem);
-  border: 1px solid var(--gs-border-muted);
-  border-radius: 18px;
-  background: var(--gs-surface-band);
-}
-
-.gs-overview-band .card {
-  border-color: rgba(51, 65, 85, 0.24);
-}
-
-.gs-overview-band .card:first-child {
-  border-color: rgba(29, 78, 216, 0.36);
-  box-shadow: 0 12px 28px rgba(29, 78, 216, 0.11);
+.gs-label {
+  color: #1e3a8a;
+  font-weight: 700;
 }
 
 .card {
@@ -94,61 +92,6 @@
 
 .card p {
   color: var(--gs-brand-slate);
-}
-
-.gs-signal-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.9rem;
-  margin-top: 0.9rem;
-}
-
-.gs-signal-grid-2 {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.gs-signal-card {
-  border: 1px solid var(--gs-border-muted);
-  border-radius: 14px;
-  background: linear-gradient(180deg, rgba(241, 245, 249, 0.72) 0%, rgba(255, 255, 255, 0.98) 100%);
-  padding: 0.9rem 1rem;
-}
-
-.gs-signal-card .icon {
-  color: var(--gs-brand-blue);
-  width: 1rem;
-  height: 1rem;
-}
-
-.gs-signal-card h3 {
-  margin: 0.4rem 0 0.25rem;
-  font-size: 0.98rem;
-}
-
-.gs-signal-card p {
-  margin: 0;
-  color: var(--gs-brand-slate);
-  font-size: 0.92rem;
-  line-height: 1.45;
-}
-
-.gs-chip-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.6rem;
-  margin-top: 0.8rem;
-}
-
-.gs-chip-row span {
-  display: inline-flex;
-  align-items: center;
-  border: 1px solid rgba(29, 78, 216, 0.25);
-  border-radius: 999px;
-  padding: 0.28rem 0.7rem;
-  font-size: 0.87rem;
-  font-weight: 600;
-  color: #1e3a8a;
-  background: rgba(219, 234, 254, 0.5);
 }
 
 body:has(.gs-hub-page) #pagination,
@@ -220,13 +163,7 @@ body:has(.gs-hub-page) .sidebar .sidebar-item[aria-current="page"] {
     padding-top: 2rem;
   }
 
-  .gs-overview-band {
-    padding: 0.82rem;
-    margin: 1.1rem 0 1.55rem;
-  }
-
-  .gs-signal-grid,
-  .gs-signal-grid-2 {
-    grid-template-columns: 1fr;
+  .prose p {
+    line-height: 1.68;
   }
 }


### PR DESCRIPTION
## Summary
- add short reader-guidance intros to dense long-form pages
- improve scanability and pacing in core principles, discovery, and customer guidance pages
- keep tone and structure aligned with Grounded Systems stance

## Files
- principles/core-principles.mdx
- playbook/discovery.mdx
- customers/what-we-help-with.mdx
- style.css

## Notes
- no runtime or API changes
- docs/content-only update