### PR TITLE
Reconfigure CMO agent adapter to opencode_local

### DIFF
--- a/agents/config/cmo-agent-adapter.config.json
+++ b/agents/config/cmo-agent-adapter.config.json
@@ -1,0 +1,14 @@
+{
+  "adapter": {
+    "name": "opencode_local",
+    "type": "ollama",
+    "model": "ollama-cloud/qwen3-coder:480b",
+    "command": "opencode",
+    "path": "/usr/local/bin/opencode"
+  },
+  "settings": {
+    "temperature": 0.7,
+    "max_tokens": 2048,
+    "timeout": 120000
+  }
+}

--- a/agents/config/cmo-agent-adapter.config.json.bak
+++ b/agents/config/cmo-agent-adapter.config.json.bak
@@ -1,0 +1,14 @@
+{
+  "adapter": {
+    "name": "opencode_local",
+    "type": "ollama",
+    "model": "ollama-cloud/qwen3-coder:480b",
+    "command": "opencode",
+    "path": "/usr/local/bin/opencode"
+  },
+  "settings": {
+    "temperature": 0.7,
+    "max_tokens": 2048,
+    "timeout": 120000
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "links": "mintlify broken-links",
     "lint:md": "markdownlint \"**/*.{md,mdx}\" --ignore node_modules",
     "format:check": "pre-commit run --all-files",
+    "setup:agent": "bash scripts/agents/setup-opencode-adapter.sh",
     "verify": "npm run links && npm run lint:md && npm run format:check"
   },
   "devDependencies": {

--- a/scripts/agents/setup-opencode-adapter.sh
+++ b/scripts/agents/setup-opencode-adapter.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Setup script for opencode agent adapter
+# Ensures opencode command is accessible in PATH
+
+set -e
+
+echo "Setting up opencode agent adapter..."
+
+# Check if opencode is already in PATH
+if command -v opencode &> /dev/null; then
+    echo "opencode command is already accessible in PATH"
+else
+    # Check if opencode binary exists in common locations
+    if [ -f "/usr/local/bin/opencode" ]; then
+        echo "opencode binary found at /usr/local/bin/opencode"
+    elif [ -f "./node_modules/.bin/opencode" ]; then
+        echo "opencode binary found at ./node_modules/.bin/opencode"
+        # Add to PATH for current session
+        export PATH="./node_modules/.bin:$PATH"
+    else
+        echo "opencode binary not found. Please install opencode first."
+        exit 1
+    fi
+fi
+
+# Verify the adapter configuration
+CONFIG_FILE="agents/config/cmo-agent-adapter.config.json"
+if [ -f "$CONFIG_FILE" ]; then
+    echo "Adapter configuration file found at $CONFIG_FILE"
+    echo "Configuration:"
+    cat "$CONFIG_FILE"
+else
+    echo "Adapter configuration file not found at $CONFIG_FILE"
+    exit 1
+fi
+
+echo "opencode agent adapter setup completed successfully!"


### PR DESCRIPTION
This PR reconfigures the CMO agent adapter to use opencode_local as requested in GROA-74.